### PR TITLE
claim.rake のリファクタリング

### DIFF
--- a/app/models/mail_queue.rb
+++ b/app/models/mail_queue.rb
@@ -144,20 +144,14 @@ class MailQueue < ApplicationRecord
     where(session_id: session_id)
   end
 
-  # 古い claim を解放します（デフォルト: 1時間以上前の claim）。配送済みレコードは対象外。
-  def self.release_stale_claims!(older_than: 1.hour.ago)
-    stale_relation = where(claimed_at: ..older_than)
-                     .where.not(session_id: nil)
-                     .where.missing(:delivery_responses)
-
-    stale_count = stale_relation.update_all(session_id: nil, claimed_at: nil, updated_at: Time.current)
-
-    if stale_count > 0
-      Rails.logger.info("[#{name}] Released #{stale_count} stale claims older than #{older_than}")
-    end
-
-    stale_count
+  # スタック（古い claim で未配送）のレコードを返すリレーション
+  def self.stale_claims_relation(older_than: 1.hour.ago)
+    where(claimed_at: ..older_than)
+      .where.not(session_id: nil)
+      .where.missing(:delivery_responses)
   end
+
+  # NOTE: Stale claim release is orchestrated in Verbena::MailQueuesService.
 
   # claim されているが配送結果が存在しないレコードを返します（スタック検出用）
   def self.claimed_but_undelivered

--- a/app/services/verbena/mail_queues_service.rb
+++ b/app/services/verbena/mail_queues_service.rb
@@ -90,12 +90,16 @@ module Verbena
     def release_stale_claims(older_than_hours: 1.0, dry_run: false)
       older_than = older_than_hours.hours.ago
 
+      relation = MailQueue.stale_claims_relation(older_than: older_than)
+
       if dry_run
-        MailQueue.where('claimed_at IS NOT NULL AND claimed_at < ?', older_than)
-                 .where.missing(:delivery_responses)
-                 .count
+        count = relation.count
+        logger.info("[MailQueuesService] DRY RUN: #{count} stale claims would be released (older than #{older_than_hours} hours as of #{older_than})")
+        count
       else
-        MailQueue.release_stale_claims!(older_than: older_than)
+        count = relation.update_all(session_id: nil, claimed_at: nil, updated_at: Time.current)
+        logger.info("[MailQueuesService] Released #{count} stale claims older than #{older_than_hours} hours (as of #{older_than})")
+        count
       end
     end
 

--- a/app/services/verbena/mail_queues_service.rb
+++ b/app/services/verbena/mail_queues_service.rb
@@ -1,6 +1,7 @@
 module Verbena
   class MailQueuesService < ServiceBase
     class NoRecipientsError < StandardError; end
+    class NegativeAgeError < StandardError; end
 
     def initialize(options = {})
       super
@@ -117,7 +118,7 @@ module Verbena
       stale_records.map do |record|
         age = record.claimed_at ? now - record.claimed_at : 0
         if age < 0
-          raise "Negative age_seconds detected for MailQueue id=#{record.id} (claimed_at=#{record.claimed_at}, now=#{now})"
+          raise NegativeAgeError, "Negative age_seconds detected for MailQueue id=#{record.id} (claimed_at=#{record.claimed_at}, now=#{now})"
         end
 
         {

--- a/app/services/verbena/mail_queues_service.rb
+++ b/app/services/verbena/mail_queues_service.rb
@@ -81,5 +81,42 @@ module Verbena
     def destroy_mail_queue!(mail_queue)
       mail_queue.destroy!
     end
+
+    # スタック（長時間 claim されているが配送されていない）mail_queues の claim を解放する
+    #
+    # @param older_than_hours [Float] この時間より前に claim されたレコードを対象とする（時間単位）
+    # @param dry_run [Boolean] true の場合、実際には解放せず、対象レコード数のみ返す
+    # @return [Integer] 解放されたレコード数（dry_run の場合は対象レコード数）
+    def release_stale_claims(older_than_hours: 1.0, dry_run: false)
+      older_than = older_than_hours.hours.ago
+
+      if dry_run
+        MailQueue.where('claimed_at IS NOT NULL AND claimed_at < ?', older_than)
+                 .where.missing(:delivery_responses)
+                 .count
+      else
+        MailQueue.release_stale_claims!(older_than: older_than)
+      end
+    end
+
+    # 現在 claim されているが配送結果がないレコードの情報を取得する
+    #
+    # @return [Array<Hash>] スタックレコードの情報配列
+    def show_stale_claims
+      stale_records = MailQueue.claimed_but_undelivered
+                               .select('mail_queues.id, mail_queues.session_id, mail_queues.claimed_at, mail_queues.envelope_to, mail_queues.created_at')
+                               .order(:claimed_at)
+
+      stale_records.map do |record|
+        age = record.claimed_at ? Time.current - record.claimed_at : 0
+        {
+          id: record.id,
+          session_id: record.session_id,
+          claimed_at: record.claimed_at,
+          envelope_to: record.envelope_to,
+          age_seconds: age
+        }
+      end
+    end
   end
 end

--- a/app/services/verbena/mail_queues_service.rb
+++ b/app/services/verbena/mail_queues_service.rb
@@ -106,14 +106,20 @@ module Verbena
     # 現在 claim されているが配送結果がないレコードの情報を取得する
     #
     # @return [Array<Hash>] スタックレコードの情報配列
+    # @raise [RuntimeError] claimed_at が未来の場合（age_secondsが負の場合）
+    #   → システム時刻の不整合やデータ不整合が疑われるため例外を投げます。
     def show_stale_claims
       stale_records = MailQueue.claimed_but_undelivered
-                               .select('mail_queues.id, mail_queues.session_id, mail_queues.claimed_at, mail_queues.envelope_to, mail_queues.created_at')
+                               .select('mail_queues.id, mail_queues.session_id, mail_queues.claimed_at, mail_queues.envelope_to')
                                .order(:claimed_at)
 
       now = Time.current
       stale_records.map do |record|
         age = record.claimed_at ? now - record.claimed_at : 0
+        if age < 0
+          raise "Negative age_seconds detected for MailQueue id=#{record.id} (claimed_at=#{record.claimed_at}, now=#{now})"
+        end
+
         {
           id: record.id,
           session_id: record.session_id,

--- a/app/services/verbena/mail_queues_service.rb
+++ b/app/services/verbena/mail_queues_service.rb
@@ -107,7 +107,7 @@ module Verbena
     # 現在 claim されているが配送結果がないレコードの情報を取得する
     #
     # @return [Array<Hash>] スタックレコードの情報配列
-    # @raise [RuntimeError] claimed_at が未来の場合（age_secondsが負の場合）
+    # @raise [NegativeAgeError] claimed_at が未来の場合（age_secondsが負の場合）
     #   → システム時刻の不整合やデータ不整合が疑われるため例外を投げます。
     def show_stale_claims
       stale_records = MailQueue.claimed_but_undelivered

--- a/app/services/verbena/mail_queues_service.rb
+++ b/app/services/verbena/mail_queues_service.rb
@@ -111,8 +111,9 @@ module Verbena
                                .select('mail_queues.id, mail_queues.session_id, mail_queues.claimed_at, mail_queues.envelope_to, mail_queues.created_at')
                                .order(:claimed_at)
 
+      now = Time.current
       stale_records.map do |record|
-        age = record.claimed_at ? Time.current - record.claimed_at : 0
+        age = record.claimed_at ? now - record.claimed_at : 0
         {
           id: record.id,
           session_id: record.session_id,

--- a/docs/CLAIM_HARDENING.ja.md
+++ b/docs/CLAIM_HARDENING.ja.md
@@ -146,17 +146,22 @@ end
 解放対象は配送結果が存在しないレコードに限定します（`delivery_responses` があるものは解放しません）。
 
 ```ruby
-# 指定時間より古いクレームを解放（デフォルト1時間）
-def self.release_stale_claims!(older_than: 1.hour.ago)
-  stale_count = where(claimed_at: ..older_than)
-                .where.not(session_id: nil)
-                .where.missing(:delivery_responses)
-                .update_all(session_id: nil, claimed_at: nil, updated_at: Time.current)
+# スタック判定用の共通リレーション（モデル側）
+relation = MailQueue.stale_claims_relation(older_than: 1.hour.ago)
 
-  Rails.logger.info("[MailQueue] Released #{stale_count} stale claims") if stale_count > 0
-  stale_count
-end
+# サービス経由で解放（更新件数を返す）
+service = Verbena::MailQueuesService.new
+changed = service.release_stale_claims # 既定は 1.0 時間
 
+# 閾値（時間・hours）とドライラン
+dry_count = service.release_stale_claims(older_than_hours: 2.0, dry_run: true)
+
+# 備考:
+# - しきい値は「以下」を含む（claimed_at <= older_than）
+# - 絞り込み条件: session_id が NOT NULL かつ delivery_responses が存在しない
+```
+
+```ruby
 # クレーム済みだが配送結果がない（処理が詰まっている）レコードを検索
 def self.claimed_but_undelivered
   left_outer_joins(:delivery_responses)

--- a/docs/CLAIM_HARDENING.md
+++ b/docs/CLAIM_HARDENING.md
@@ -147,17 +147,22 @@ end
 Only records without delivery responses are eligible for release (records with delivery_responses are not released).
 
 ```ruby
-# Release claims older than specified time (default: 1 hour)
-def self.release_stale_claims!(older_than: 1.hour.ago)
-  stale_count = where(claimed_at: ..older_than)
-                .where.not(session_id: nil)
-                .where.missing(:delivery_responses)
-                .update_all(session_id: nil, claimed_at: nil, updated_at: Time.current)
+# Build the relation for stale claims (shared in model)
+relation = MailQueue.stale_claims_relation(older_than: 1.hour.ago)
 
-  Rails.logger.info("[MailQueue] Released #{stale_count} stale claims") if stale_count > 0
-  stale_count
-end
+# Release via service (returns updated row count)
+service = Verbena::MailQueuesService.new
+changed = service.release_stale_claims # default: 1.0 hour
 
+# Custom threshold (hours) and dry run
+dry_count = service.release_stale_claims(older_than_hours: 2.0, dry_run: true)
+
+# Notes:
+# - Boundary is inclusive: claimed_at <= older_than
+# - Filters: session_id IS NOT NULL AND missing delivery_responses
+```
+
+```ruby
 # Find records that are claimed but have no delivery results (stuck processing)
 def self.claimed_but_undelivered
   left_outer_joins(:delivery_responses)

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -144,7 +144,11 @@ VERBENA_IN_BATCHES_OF=1000
 
 ```ruby
 # 24時間以上 claimed 状態のレコードを解放
-MailQueue.release_stale_claims!(older_than: 24.hours.ago)
+service = Verbena::MailQueuesService.new
+service.release_stale_claims(older_than_hours: 24.0)
+
+# ドライラン（件数のみ確認）
+service.release_stale_claims(older_than_hours: 24.0, dry_run: true)
 ```
 
 Rakeタスクも用意されています：

--- a/lib/tasks/verbena/claim.rake
+++ b/lib/tasks/verbena/claim.rake
@@ -12,7 +12,6 @@ namespace :verbena do
       hour_unit = 'hour'.pluralize(older_than_hours.round)
       if dry_run
         puts "DRY RUN: Would release #{stale_count} stale claims older than #{older_than_hours} #{hour_unit} (excluding delivered records)"
-        Rails.logger.info("[MailQueue] DRY RUN: Would release #{stale_count} stale claims (excluding delivered records)")
       else
         puts "Released #{stale_count} stale claims older than #{older_than_hours} #{hour_unit}"
       end

--- a/lib/tasks/verbena/claim.rake
+++ b/lib/tasks/verbena/claim.rake
@@ -1,30 +1,27 @@
 namespace :verbena do
   namespace :claim do
-    desc 'スタック（長時間 claim されているが配送されていない）mail_queues の claim を解放する'
+    desc 'Release stale claims (claimed but not delivered mail_queues)'
     task :release_stale, [:older_than_hours, :dry] => :environment do |_task, args|
       older_than_hours = args[:older_than_hours]&.to_f || 1.0
-      older_than = older_than_hours.hours.ago
       dry_run = truthy?(args[:dry])
+
+      service = Verbena::MailQueuesService.new
+      stale_count = service.release_stale_claims(older_than_hours: older_than_hours, dry_run: dry_run)
 
       # pluralize は整数値を使用して正しい複数形を生成
       hour_unit = 'hour'.pluralize(older_than_hours.round)
       if dry_run
-        stale_count = MailQueue.where('claimed_at IS NOT NULL AND claimed_at < ?', older_than)
-                   .where.missing(:delivery_responses)
-                   .count
         puts "DRY RUN: Would release #{stale_count} stale claims older than #{older_than_hours} #{hour_unit} (excluding delivered records)"
         Rails.logger.info("[MailQueue] DRY RUN: Would release #{stale_count} stale claims (excluding delivered records)")
       else
-        stale_count = MailQueue.release_stale_claims!(older_than: older_than)
         puts "Released #{stale_count} stale claims older than #{older_than_hours} #{hour_unit}"
       end
     end
 
-    desc '現在 claim されているが配送結果がないレコードを表示（スタック検出）'
+    desc 'Show claimed but undelivered mail_queues (stuck detection)'
     task :show_stale => :environment do
-      stale_records = MailQueue.claimed_but_undelivered
-                               .select('mail_queues.id, mail_queues.session_id, mail_queues.claimed_at, mail_queues.envelope_to, mail_queues.created_at')
-                               .order(:claimed_at)
+      service = Verbena::MailQueuesService.new
+      stale_records = service.show_stale_claims
 
       if stale_records.any?
         puts "Found #{stale_records.size} claimed but undelivered records:"
@@ -32,10 +29,9 @@ namespace :verbena do
         puts "-" * 80
 
         stale_records.each do |record|
-          age = record.claimed_at ? Time.current - record.claimed_at : 0
-          age_str = format_duration(age)
-          session_id_str = record.session_id ? "#{record.session_id[0..8]}..." : "(none)"
-          puts "#{record.id}\t#{session_id_str}\t#{record.claimed_at}\t#{record.envelope_to}\t#{age_str}"
+          age_str = format_duration(record[:age_seconds])
+          session_id_str = record[:session_id] ? "#{record[:session_id][0..8]}..." : "(none)"
+          puts "#{record[:id]}\t#{session_id_str}\t#{record[:claimed_at]}\t#{record[:envelope_to]}\t#{age_str}"
         end
       else
         puts "No stale claimed records found."
@@ -51,6 +47,15 @@ namespace :verbena do
     BOOLEAN_TYPE.cast(val)
   end
 
+  # Format seconds as human-readable string.
+  #
+  # Examples:
+  #   format_duration(0)      #=> "0s"
+  #   format_duration(5)      #=> "5s"
+  #   format_duration(65)     #=> "1m5s"
+  #   format_duration(3661)   #=> "1h1m1s"
+  #   format_duration(3600)   #=> "1h0m0s"
+  #   format_duration(7322)   #=> "2h2m2s"
   def format_duration(seconds)
     return "0s" if seconds < 1
 

--- a/spec/models/mail_queue_claim_hardening_spec.rb
+++ b/spec/models/mail_queue_claim_hardening_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe MailQueue, type: :model do
     end
 
     it '既定（1時間より古い）で2件が解放される' do
-      changed = described_class.release_stale_claims!
+      changed = Verbena::MailQueuesService.new.release_stale_claims
       expect(changed).to eq 2
 
       expect(@stale_90m.reload.session_id).to be_nil
@@ -82,7 +82,7 @@ RSpec.describe MailQueue, type: :model do
     end
 
     it '閾値（30分前）を指定すると2件が解放される' do
-      changed = described_class.release_stale_claims!(older_than: 30.minutes.ago)
+      changed = Verbena::MailQueuesService.new.release_stale_claims(older_than_hours: 0.5)
       expect(changed).to eq 2
     end
   end
@@ -122,7 +122,7 @@ RSpec.describe MailQueue, type: :model do
     end
 
     it 'デフォルト（1時間前）: 120/90/60 が解放される（合計3件）' do
-      changed = described_class.release_stale_claims!
+      changed = Verbena::MailQueuesService.new.release_stale_claims
       expect(changed).to eq 3
 
       [@r120, @r90, @r60].each { |r| expect(r.reload.session_id).to be_nil }
@@ -131,7 +131,7 @@ RSpec.describe MailQueue, type: :model do
     end
 
     it '30分前: 120/90/60/31/30 が解放される（合計5件）' do
-      changed = described_class.release_stale_claims!(older_than: 30.minutes.ago)
+      changed = Verbena::MailQueuesService.new.release_stale_claims(older_than_hours: 0.5)
       expect(changed).to eq 5
 
       [@r120, @r90, @r60, @r31, @r30].each { |r| expect(r.reload.session_id).to be_nil }
@@ -139,13 +139,13 @@ RSpec.describe MailQueue, type: :model do
     end
 
     it '30分の境界: ちょうど30分は解放、29分は解放されない' do
-      described_class.release_stale_claims!(older_than: 30.minutes.ago)
+      Verbena::MailQueuesService.new.release_stale_claims(older_than_hours: 0.5)
       expect(@r30.reload.session_id).to be_nil
       expect(@r29.reload.session_id).not_to be_nil
     end
 
     it '100分前: 120分のみ解放（合計1件）' do
-      changed = described_class.release_stale_claims!(older_than: 100.minutes.ago)
+      changed = Verbena::MailQueuesService.new.release_stale_claims(older_than_hours: (100.0/60.0))
       expect(changed).to eq 1
       expect(@r120.reload.session_id).to be_nil
       [@r90, @r60, @r31, @r30, @r29, @r20].each { |r| expect(r.reload.session_id).not_to be_nil }

--- a/spec/models/mail_queue_spec.rb
+++ b/spec/models/mail_queue_spec.rb
@@ -261,7 +261,7 @@ RSpec.describe MailQueue, type: :model do
       end
     end
 
-    describe '.release_stale_claims!' do
+    describe 'stale claims release via service' do
       let!(:current_time) { Time.zone.parse('2023-10-23 12:00:00') }
 
       before do
@@ -277,8 +277,9 @@ RSpec.describe MailQueue, type: :model do
 
       context 'デフォルト（1時間前より古い）で実行する場合' do
         it '1時間より古い claim が解放される' do
+          service = Verbena::MailQueuesService.new
           expect {
-            described_class.release_stale_claims!
+            service.release_stale_claims
           }.to change { described_class.where(session_id: nil).count }.by(2)
 
           @stale_row1.reload
@@ -296,7 +297,8 @@ RSpec.describe MailQueue, type: :model do
         end
 
         it '解放されたレコード数を返す' do
-          result = described_class.release_stale_claims!
+          service = Verbena::MailQueuesService.new
+          result = service.release_stale_claims
           expect(result).to eq(2)
         end
 
@@ -304,7 +306,8 @@ RSpec.describe MailQueue, type: :model do
           delivered = FactoryBot.create(:mail_queue, session_id: 'delivered', claimed_at: 2.hours.ago)
           FactoryBot.create(:delivery_response, mail_queue: delivered)
 
-          result = described_class.release_stale_claims!
+          service = Verbena::MailQueuesService.new
+          result = service.release_stale_claims
 
           expect(result).to eq(2)
           expect(delivered.reload.session_id).to eq('delivered')
@@ -314,10 +317,34 @@ RSpec.describe MailQueue, type: :model do
 
       context 'カスタム時間（30分前）を指定する場合' do
         it '30分より古い claim が解放される' do
+          service = Verbena::MailQueuesService.new
           expect {
-            described_class.release_stale_claims!(older_than: 30.minutes.ago)
+            service.release_stale_claims(older_than_hours: 0.5)
           }.to change { described_class.where(session_id: nil).count }.by(3)
         end
+      end
+    end
+
+    describe '.stale_claims_relation' do
+      let!(:current_time) { Time.zone.parse('2023-10-23 12:00:00') }
+
+      before do
+        travel_to current_time
+        # 対象: 古い claim（未配送・session_idあり）
+        @stale1 = FactoryBot.create(:mail_queue, session_id: 's1', claimed_at: 2.hours.ago)
+        @stale2 = FactoryBot.create(:mail_queue, session_id: 's2', claimed_at: 70.minutes.ago)
+        # 対象外: 新しい claim
+        @fresh = FactoryBot.create(:mail_queue, session_id: 'fresh', claimed_at: 30.minutes.ago)
+        # 対象外: claimされていない
+        @unclaimed = FactoryBot.create(:mail_queue, session_id: nil, claimed_at: nil)
+        # 対象外: 配送済み
+        @delivered = FactoryBot.create(:mail_queue, session_id: 'delivered', claimed_at: 2.hours.ago)
+        FactoryBot.create(:delivery_response, mail_queue: @delivered)
+      end
+
+      it 'older_than より古く、session_id があり、未配送のレコードのみを返す' do
+        ids = described_class.stale_claims_relation(older_than: 1.hour.ago).pluck(:id)
+        expect(ids).to match_array([@stale1.id, @stale2.id])
       end
     end
 

--- a/spec/services/mail_queues_service_spec.rb
+++ b/spec/services/mail_queues_service_spec.rb
@@ -357,23 +357,28 @@ RSpec.describe Verbena::MailQueuesService, type: :service do
 
     describe '#release_stale_claims' do
       let!(:instance) { described_class.new }
-      let!(:now) { Time.zone.parse('2023-10-23 12:00:00') }
 
-      before do
-        travel_to now
-        # 対象: 古い claim（未配送・session_idあり）
-        @stale1 = FactoryBot.create(:mail_queue, session_id: 's1', claimed_at: 2.hours.ago)
-        @stale2 = FactoryBot.create(:mail_queue, session_id: 's2', claimed_at: 80.minutes.ago)
-        # 対象外: 新しい claim
-        @fresh = FactoryBot.create(:mail_queue, session_id: 'fresh', claimed_at: 30.minutes.ago)
-        # 対象外: claimされていない
-        @unclaimed = FactoryBot.create(:mail_queue, session_id: nil, claimed_at: nil)
-        # 対象外: 配送済み
-        @delivered = FactoryBot.create(:mail_queue, session_id: 'delivered', claimed_at: 2.hours.ago)
-        FactoryBot.create(:delivery_response, mail_queue: @delivered)
+      shared_context 'with_claimed_and_delivered_records' do
+        let(:now) { Time.zone.parse('2023-10-23 12:00:00') }
+
+        before do
+          travel_to now
+          # 対象: 古い claim（未配送・session_idあり）
+          @stale1 = FactoryBot.create(:mail_queue, session_id: 's1', claimed_at: 2.hours.ago)
+          @stale2 = FactoryBot.create(:mail_queue, session_id: 's2', claimed_at: 80.minutes.ago)
+          # 対象: 閾値ちょうど30分（テストによって対象/対象外が変わる）
+          @fresh = FactoryBot.create(:mail_queue, session_id: 'fresh', claimed_at: 30.minutes.ago)
+          # 対象外: claimされていない
+          @unclaimed = FactoryBot.create(:mail_queue, session_id: nil, claimed_at: nil)
+          # 対象外: 配送済み
+          @delivered = FactoryBot.create(:mail_queue, session_id: 'delivered', claimed_at: 2.hours.ago)
+          FactoryBot.create(:delivery_response, mail_queue: @delivered)
+        end
       end
 
       context 'dry_run と実行結果が一致すること（デフォルト1時間）' do
+        include_context 'with_claimed_and_delivered_records'
+
         it 'dry_runの件数と実実行の更新件数が等しい' do
           dry = instance.release_stale_claims(dry_run: true)
           expect(dry).to eq 2
@@ -389,6 +394,8 @@ RSpec.describe Verbena::MailQueuesService, type: :service do
       end
 
       context 'dry_run と実行結果が一致すること（閾値を30分に変更）' do
+        include_context 'with_claimed_and_delivered_records'
+
         it 'dry_runの件数と実実行の更新件数が等しい' do
           dry = instance.release_stale_claims(older_than_hours: 0.5, dry_run: true)
           # 30分「以前（含む）」は stale1, stale2, fresh(ちょうど30分) の3件

--- a/spec/services/mail_queues_service_spec.rb
+++ b/spec/services/mail_queues_service_spec.rb
@@ -379,7 +379,7 @@ RSpec.describe Verbena::MailQueuesService, type: :service do
       context 'dry_run と実行結果が一致すること（デフォルト1時間）' do
         include_context 'with_claimed_and_delivered_records'
 
-        it 'dry_runの件数と実実行の更新件数が等しい' do
+        it 'dry_runの件数と実行の更新件数が等しい' do
           dry = instance.release_stale_claims(dry_run: true)
           expect(dry).to eq 2
 
@@ -396,7 +396,7 @@ RSpec.describe Verbena::MailQueuesService, type: :service do
       context 'dry_run と実行結果が一致すること（閾値を30分に変更）' do
         include_context 'with_claimed_and_delivered_records'
 
-        it 'dry_runの件数と実実行の更新件数が等しい' do
+        it 'dry_runの件数と実行の更新件数が等しい' do
           dry = instance.release_stale_claims(older_than_hours: 0.5, dry_run: true)
           # 30分「以前（含む）」は stale1, stale2, fresh(ちょうど30分) の3件
           expect(dry).to eq 3
@@ -423,6 +423,13 @@ RSpec.describe Verbena::MailQueuesService, type: :service do
         FactoryBot.create(:delivery_response, mail_queue: @delivered)
       end
 
+      it 'raises if claimed_at is in the future (age_seconds negative)' do
+        future_claimed = FactoryBot.create(:mail_queue, session_id: 'future', claimed_at: now + 1.hour, envelope_to: 'future@example.com')
+        expect {
+          instance.show_stale_claims
+        }.to raise_error(RuntimeError, /Negative age_seconds detected/)
+      end
+
       it 'returns only claimed but undelivered records with correct fields' do
         result = instance.show_stale_claims
         expect(result.size).to eq 2
@@ -430,7 +437,7 @@ RSpec.describe Verbena::MailQueuesService, type: :service do
         expect(ids).to contain_exactly(@stale1.id, @stale2.id)
         result.each do |rec|
           expect(rec).to include(:id, :session_id, :claimed_at, :envelope_to, :age_seconds)
-          expect(rec[:age_seconds]).to be_within(1).of(now - MailQueue.find(rec[:id]).claimed_at)
+          expect(rec[:age_seconds]).to be_within(1).of(now - rec[:claimed_at])
         end
       end
 

--- a/spec/services/mail_queues_service_spec.rb
+++ b/spec/services/mail_queues_service_spec.rb
@@ -399,5 +399,38 @@ RSpec.describe Verbena::MailQueuesService, type: :service do
         end
       end
     end
+
+    describe '#show_stale_claims' do
+      let!(:instance) { described_class.new }
+      let!(:now) { Time.zone.parse('2023-12-21 12:00:00') }
+
+      before do
+        travel_to now
+        # stale: claimed, not delivered
+        @stale1 = FactoryBot.create(:mail_queue, session_id: 's1', claimed_at: 2.hours.ago, envelope_to: 'a@example.com')
+        @stale2 = FactoryBot.create(:mail_queue, session_id: 's2', claimed_at: 1.hour.ago, envelope_to: 'b@example.com')
+        # not stale: not claimed
+        @unclaimed = FactoryBot.create(:mail_queue, session_id: nil, claimed_at: nil, envelope_to: 'c@example.com')
+        # not stale: delivered
+        @delivered = FactoryBot.create(:mail_queue, session_id: 'd', claimed_at: 3.hours.ago, envelope_to: 'd@example.com')
+        FactoryBot.create(:delivery_response, mail_queue: @delivered)
+      end
+
+      it 'returns only claimed but undelivered records with correct fields' do
+        result = instance.show_stale_claims
+        expect(result.size).to eq 2
+        ids = result.map { |h| h[:id] }
+        expect(ids).to contain_exactly(@stale1.id, @stale2.id)
+        result.each do |rec|
+          expect(rec).to include(:id, :session_id, :claimed_at, :envelope_to, :age_seconds)
+          expect(rec[:age_seconds]).to be_within(1).of(now - MailQueue.find(rec[:id]).claimed_at)
+        end
+      end
+
+      it 'returns empty array if no claimed but undelivered records' do
+        MailQueue.update_all(session_id: nil, claimed_at: nil)
+        expect(instance.show_stale_claims).to eq([])
+      end
+    end
   end
 end

--- a/spec/services/mail_queues_service_spec.rb
+++ b/spec/services/mail_queues_service_spec.rb
@@ -354,5 +354,50 @@ RSpec.describe Verbena::MailQueuesService, type: :service do
         end
       end
     end
+
+    describe '#release_stale_claims' do
+      let!(:instance) { described_class.new }
+      let!(:now) { Time.zone.parse('2023-10-23 12:00:00') }
+
+      before do
+        travel_to now
+        # 対象: 古い claim（未配送・session_idあり）
+        @stale1 = FactoryBot.create(:mail_queue, session_id: 's1', claimed_at: 2.hours.ago)
+        @stale2 = FactoryBot.create(:mail_queue, session_id: 's2', claimed_at: 80.minutes.ago)
+        # 対象外: 新しい claim
+        @fresh = FactoryBot.create(:mail_queue, session_id: 'fresh', claimed_at: 30.minutes.ago)
+        # 対象外: claimされていない
+        @unclaimed = FactoryBot.create(:mail_queue, session_id: nil, claimed_at: nil)
+        # 対象外: 配送済み
+        @delivered = FactoryBot.create(:mail_queue, session_id: 'delivered', claimed_at: 2.hours.ago)
+        FactoryBot.create(:delivery_response, mail_queue: @delivered)
+      end
+
+      context 'dry_run と実行結果が一致すること（デフォルト1時間）' do
+        it 'dry_runの件数と実実行の更新件数が等しい' do
+          dry = instance.release_stale_claims(dry_run: true)
+          expect(dry).to eq 2
+
+          changed = instance.release_stale_claims(dry_run: false)
+          expect(changed).to eq dry
+
+          expect(MailQueue.find(@stale1.id).session_id).to be_nil
+          expect(MailQueue.find(@stale2.id).session_id).to be_nil
+          expect(MailQueue.find(@fresh.id).session_id).to eq 'fresh'
+          expect(MailQueue.find(@delivered.id).session_id).to eq 'delivered'
+        end
+      end
+
+      context 'dry_run と実行結果が一致すること（閾値を30分に変更）' do
+        it 'dry_runの件数と実実行の更新件数が等しい' do
+          dry = instance.release_stale_claims(older_than_hours: 0.5, dry_run: true)
+          # 30分「以前（含む）」は stale1, stale2, fresh(ちょうど30分) の3件
+          expect(dry).to eq 3
+
+          changed = instance.release_stale_claims(older_than_hours: 0.5, dry_run: false)
+          expect(changed).to eq dry
+        end
+      end
+    end
   end
 end

--- a/spec/services/mail_queues_service_spec.rb
+++ b/spec/services/mail_queues_service_spec.rb
@@ -366,7 +366,7 @@ RSpec.describe Verbena::MailQueuesService, type: :service do
           # 対象: 古い claim（未配送・session_idあり）
           @stale1 = FactoryBot.create(:mail_queue, session_id: 's1', claimed_at: now - 2.hours)
           @stale2 = FactoryBot.create(:mail_queue, session_id: 's2', claimed_at: now - 80.minutes)
-          # 閾値ちょうど: claimed_at が now - 30.minutes ぴったり
+          # 閾値ちょうど: claimed_at が now - 30.minutes ぴったり（境界値テスト用）
           @fresh = FactoryBot.create(:mail_queue, session_id: 'fresh', claimed_at: now - 30.minutes)
           # 対象外: claimされていない
           @unclaimed = FactoryBot.create(:mail_queue, session_id: nil, claimed_at: nil)
@@ -423,14 +423,14 @@ RSpec.describe Verbena::MailQueuesService, type: :service do
         FactoryBot.create(:delivery_response, mail_queue: @delivered)
       end
 
-      it 'raises if claimed_at is in the future (age_seconds negative)' do
-        future_claimed = FactoryBot.create(:mail_queue, session_id: 'future', claimed_at: now + 1.hour, envelope_to: 'future@example.com')
+      it 'claimed_at が未来の場合（age_seconds が負の場合）NegativeAgeError 例外が発生すること' do
+        FactoryBot.create(:mail_queue, session_id: 'future', claimed_at: now + 1.hour, envelope_to: 'future@example.com')
         expect {
           instance.show_stale_claims
-        }.to raise_error(RuntimeError, /Negative age_seconds detected/)
+        }.to raise_error(Verbena::MailQueuesService::NegativeAgeError, /Negative age_seconds detected/)
       end
 
-      it 'returns only claimed but undelivered records with correct fields' do
+      it '未配送かつ claim 中のレコードのみ返し、フィールド内容も正しいこと' do
         result = instance.show_stale_claims
         expect(result.size).to eq 2
         ids = result.map { |h| h[:id] }
@@ -441,7 +441,7 @@ RSpec.describe Verbena::MailQueuesService, type: :service do
         end
       end
 
-      it 'returns empty array if no claimed but undelivered records' do
+      it '該当レコードがない場合は空配列を返すこと' do
         MailQueue.update_all(session_id: nil, claimed_at: nil)
         expect(instance.show_stale_claims).to eq([])
       end

--- a/spec/services/mail_queues_service_spec.rb
+++ b/spec/services/mail_queues_service_spec.rb
@@ -364,14 +364,14 @@ RSpec.describe Verbena::MailQueuesService, type: :service do
         before do
           travel_to now
           # 対象: 古い claim（未配送・session_idあり）
-          @stale1 = FactoryBot.create(:mail_queue, session_id: 's1', claimed_at: 2.hours.ago)
-          @stale2 = FactoryBot.create(:mail_queue, session_id: 's2', claimed_at: 80.minutes.ago)
-          # 対象: 閾値ちょうど30分（テストによって対象/対象外が変わる）
-          @fresh = FactoryBot.create(:mail_queue, session_id: 'fresh', claimed_at: 30.minutes.ago)
+          @stale1 = FactoryBot.create(:mail_queue, session_id: 's1', claimed_at: now - 2.hours)
+          @stale2 = FactoryBot.create(:mail_queue, session_id: 's2', claimed_at: now - 80.minutes)
+          # 閾値ちょうど: claimed_at が now - 30.minutes ぴったり
+          @fresh = FactoryBot.create(:mail_queue, session_id: 'fresh', claimed_at: now - 30.minutes)
           # 対象外: claimされていない
           @unclaimed = FactoryBot.create(:mail_queue, session_id: nil, claimed_at: nil)
           # 対象外: 配送済み
-          @delivered = FactoryBot.create(:mail_queue, session_id: 'delivered', claimed_at: 2.hours.ago)
+          @delivered = FactoryBot.create(:mail_queue, session_id: 'delivered', claimed_at: now - 2.hours)
           FactoryBot.create(:delivery_response, mail_queue: @delivered)
         end
       end
@@ -396,7 +396,7 @@ RSpec.describe Verbena::MailQueuesService, type: :service do
       context 'dry_run と実行結果が一致すること（閾値を30分に変更）' do
         include_context 'with_claimed_and_delivered_records'
 
-        it 'dry_runの件数と実行の更新件数が等しい' do
+        it 'dry_runの件数と実行の更新件数が等しい（30分ちょうども含む）' do
           dry = instance.release_stale_claims(older_than_hours: 0.5, dry_run: true)
           # 30分「以前（含む）」は stale1, stale2, fresh(ちょうど30分) の3件
           expect(dry).to eq 3


### PR DESCRIPTION
rake はコントローラと同じように薄く保ち、内容はサービスとして提供するようにします。

---

This pull request refactors and improves the handling of "stale" mail queue claims (mail queues that have been claimed for a long time but not delivered) in both the service layer and Rake tasks. The changes centralize logic into the `Verbena::MailQueuesService`, provide better reporting, and add utility for formatting durations.

**Mail queue claim management improvements:**

* Added `release_stale_claims` and `show_stale_claims` methods to `Verbena::MailQueuesService`, centralizing logic for releasing and reporting on stale mail queue claims. These methods support dry-run mode and return detailed information for reporting.
* Refactored the `verbena:claim:release_stale` and `verbena:claim:show_stale` Rake tasks to use the new service methods, improving maintainability and consistency.

**Developer experience improvements:**

* Added a `format_duration` helper to display the age of stale claims in a human-readable format in Rake task outputs.