### PR TITLE
ドキュメント整合性改善（環境変数一覧）

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,18 +92,11 @@ Token.create_unique!(label: "hoge", key: "user-secret", expires_at: 1.year.from_
   $ bundle exec rake verbena:tokens:revoke_expired
   ```
 
-### SMTP/配送設定
+### 環境変数リファレンス
 
 アプリケーションの設定は環境変数で行います。
 
-主要な環境変数：
-- VERBENA_DELIVERY_METHOD=smtp|test|file（開発/テストは `test`、本番は `smtp` が想定の既定）
-- VERBENA_DELIVERY_SMTP_ADDRESS, VERBENA_DELIVERY_SMTP_PORT, VERBENA_DELIVERY_SMTP_DOMAIN,
-  VERBENA_DELIVERY_SMTP_USER_NAME, VERBENA_DELIVERY_SMTP_PASSWORD, VERBENA_DELIVERY_SMTP_AUTHENTICATION,
-  VERBENA_DELIVERY_SMTP_ENABLE_STARTTLS_AUTO
-- VERBENA_FILE_DELIVERY_DIR（file モード時の保存先。未指定時は `tmp/mails`）
-- VERBENA_ENVELOPE_FROM_OVERRIDE（SMTP の envelope-from を強制上書き、任意）
-
+Verbena で利用可能な環境変数のリストは [docs/ENVIRONMENT_VARIABLES.md](docs/ENVIRONMENT_VARIABLES.md) を参照してください。
 
 ## 実行方法
 
@@ -129,7 +122,7 @@ $ curl -D - -H 'Authorization: Bearer user-secret' -X POST \
     http://localhost:13000/api/v1/mail_queues
 ```
 
-いずれの場合でも、入力したメールのヘッダ To: Cc: Bcc: に記されたメールアドレスの数だけ `mail_queues` が作成されます。例えば `/path/to/source.eml` が次の内容であったとした場合、そのヘッダ "To:" "Cc:" "Bcc:" に基づき 4 件の `mail_queues` レコードが作成されます。
+いずれの場合でも、入力したメールのヘッダ "To:" "Cc:" "Bcc:" に記されたメールアドレスの数だけ `mail_queues` が作成されます。例えば `/path/to/source.eml` が次の内容であったとした場合、そのヘッダ "To:" "Cc:" "Bcc:" に基づき 4 件の `mail_queues` レコードが作成されます。
 
 ```sh
 Date: Tue, 1 Jul 2003 10:52:37 +0200

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -1,0 +1,84 @@
+# Verbena 環境変数リファレンス
+
+Verbena アプリケーションの設定に用いられる環境変数を説明します。
+
+開発者向けの情報として、詳細な挙動や型、値の正規化については `config/initializers/verbena_env.rb` を参照してください。
+
+## 配送設定
+
+### 基本設定
+
+| 変数名 | 用途 | 必須/任意 | 既定値 | 説明 |
+|--------|------|-----------|--------|------|
+| VERBENA_DELIVERY_METHOD | 配送方式 | 任意 | test（開発）/smtp（本番） | smtp / test / file |
+| VERBENA_ENVELOPE_FROM_OVERRIDE | Envelope-From上書き | 任意 | なし | SMTPのenvelope-from強制上書き |
+
+### SMTP設定
+
+SMTP配送（`VERBENA_DELIVERY_METHOD=smtp`）を使用する場合に必要な設定です。
+
+| 変数名 | 用途 | 必須/任意 | 既定値 | 説明 |
+|--------|------|-----------|--------|------|
+| VERBENA_DELIVERY_SMTP_ADDRESS | SMTPサーバ | smtp時必須 | なし | SMTP配送時のサーバアドレス |
+| VERBENA_DELIVERY_SMTP_PORT | SMTPポート | smtp時必須 | なし | SMTP配送時のポート番号 |
+| VERBENA_DELIVERY_SMTP_DOMAIN | SMTPドメイン | smtp時必須 | なし | SMTP配送時のHELOドメイン |
+| VERBENA_DELIVERY_SMTP_USER_NAME | SMTPユーザ名 | smtp時必須 | なし | SMTP認証ユーザ名 |
+| VERBENA_DELIVERY_SMTP_PASSWORD | SMTPパスワード | smtp時必須 | なし | SMTP認証パスワード |
+| VERBENA_DELIVERY_SMTP_AUTHENTICATION | SMTP認証方式 | smtp時必須 | なし | plain / login など |
+| VERBENA_DELIVERY_SMTP_ENABLE_STARTTLS_AUTO | STARTTLS有効 | 任意 | true | SMTPでSTARTTLSを有効化 |
+
+### ファイル配送設定
+
+ファイル配送（`VERBENA_DELIVERY_METHOD=file`）を使用する場合の設定です。
+
+| 変数名 | 用途 | 必須/任意 | 既定値 | 説明 |
+|--------|------|-----------|--------|------|
+| VERBENA_FILE_DELIVERY_DIR | ファイル配送先 | file時任意 | tmp/mails | fileモード時の保存先 |
+
+## 処理制御
+
+### 並列・バッチ処理
+
+| 変数名 | 用途 | 必須/任意 | 既定値 | 説明 |
+|--------|------|-----------|--------|------|
+| VERBENA_PARALLEL_TYPE | 並列処理方式 | 任意 | in_threads | in_threads など |
+| VERBENA_PARALLEL_CONCURRENCY | 並列数 | 任意 | 2 | 並列配送時のスレッド数等 |
+| VERBENA_IN_BATCHES_OF | バッチサイズ | 任意 | 100 | 一括配送時のバッチ件数 |
+
+### リトライ・バックオフ
+
+| 変数名 | 用途 | 必須/任意 | 既定値 | 説明 |
+|--------|------|-----------|--------|------|
+| VERBENA_CLAIM_BACKOFF_BASE_SECONDS | クレーム初期待機秒 | 任意 | 1.0 | 配送リトライ時の初期待機秒数 |
+| VERBENA_CLAIM_BACKOFF_CAP_SECONDS | クレーム最大待機秒 | 任意 | 300.0 | 配送リトライ時の最大待機秒数 |
+| VERBENA_CLAIM_MAX_RETRIES | クレーム最大リトライ回数 | 任意 | 5 | 配送リトライの最大回数 |
+
+## API設定
+
+### ページネーション
+
+| 変数名 | 用途 | 必須/任意 | 既定値 | 説明 |
+|--------|------|-----------|--------|------|
+| VERBENA_API_PAGINATION_DEFAULT_LIMIT | APIページネーション既定件数 | 任意 | 50 | APIレスポンスのデフォルト件数 |
+| VERBENA_API_PAGINATION_LIMIT_CAP | APIページネーション上限 | 任意 | 1000 | APIレスポンスの最大件数 |
+| VERBENA_API_PAGINATION_DEFAULT_OFFSET | APIページネーション既定オフセット | 任意 | 0 | APIレスポンスのデフォルトオフセット |
+
+## データ保守
+
+### サイズ制限
+
+| 変数名 | 用途 | 必須/任意 | 既定値 | 説明 |
+|--------|------|-----------|--------|------|
+| VERBENA_EML_MAX_BYTES | EML最大サイズ | 任意 | 10485760 | 受信EMLの最大バイト数 |
+
+### クリーンアップ
+
+| 変数名 | 用途 | 必須/任意 | 既定値 | 説明 |
+|--------|------|-----------|--------|------|
+| VERBENA_CLEANUP_TTL_DAYS | クリーンアップ保持日数 | 任意 | 30 | 配送済みデータの保持日数 |
+
+## システム設定
+
+| 変数名 | 用途 | 必須/任意 | 既定値 | 説明 |
+|--------|------|-----------|--------|------|
+| VERBENA_LOG_FORMAT | ログ出力形式 | 任意 | text | text / json |

--- a/dot.env.sample
+++ b/dot.env.sample
@@ -35,7 +35,6 @@ VERBENA_IN_BATCHES_OF=100
 
 # General
 VERBENA_EML_MAX_BYTES=10485760
-VERBENA_TIME_ZONE=UTC
 
 # API pagination (optional overrides)
 # Default limit=50, cap=1000, offset=0 when unset
@@ -48,9 +47,9 @@ VERBENA_LOG_FORMAT=text
 VERBENA_CLEANUP_TTL_DAYS=30
 
 # Claim / backoff tuning (optional)
-# - VERBENA_CLAIM_BACKOFF_BASE_SECONDS: 初期待ち時間（秒、float）。デフォルト: 1.0
-# - VERBENA_CLAIM_BACKOFF_CAP_SECONDS:  最大待ち時間（秒、float）。デフォルト: 300.0
-# - VERBENA_CLAIM_MAX_RETRIES:         最大リトライ回数（整数）。デフォルト: 5
+# - VERBENA_CLAIM_BACKOFF_BASE_SECONDS: Initial backoff time (seconds, float). Default: 1.0
+# - VERBENA_CLAIM_BACKOFF_CAP_SECONDS:  Maximum backoff time (seconds, float). Default: 300.0
+# - VERBENA_CLAIM_MAX_RETRIES:         Maximum retry count (integer). Default: 5
 VERBENA_CLAIM_BACKOFF_BASE_SECONDS=1.0
 VERBENA_CLAIM_BACKOFF_CAP_SECONDS=300.0
 VERBENA_CLAIM_MAX_RETRIES=5


### PR DESCRIPTION
#14 の対応です。

- タイムゾーン方針については #10 で対応済み
- 環境変数一覧を別ドキュメント  ENVIRONMENT_VARIABLES.md に整理
- 未使用の環境変数（VERBENA_TIME_ZONE）を除外

---

This pull request improves documentation for environment variable configuration in the Verbena application. The main changes include replacing the environment variable section in `README.md` with a reference to a new, detailed environment variable reference file, adding the new reference file, and updating comments in `dot.env.sample` for clarity and consistency.

**Documentation improvements:**

* Replaced the list of major environment variables in the `README.md` with a link to the new `docs/ENVIRONMENT_VARIABLES.md` file, making configuration guidance more maintainable and discoverable.
* Added `docs/ENVIRONMENT_VARIABLES.md`, a comprehensive reference detailing all supported environment variables, their usage, defaults, requirements, and descriptions.

**Sample and comment enhancements:**

* Updated comments in `dot.env.sample` to provide clearer English explanations for claim/backoff tuning variables, improving readability for non-Japanese speakers.
* Removed the unused `VERBENA_TIME_ZONE` variable from `dot.env.sample` to keep the sample file accurate and up-to-date.

**Minor documentation correction:**

* Fixed a minor wording issue in the `README.md` regarding mail header processing for clarity and consistency.