### PR TITLE
Refactor time limit handling in DeliveryResponse and DeliveryService

### DIFF
--- a/app/models/delivery_response.rb
+++ b/app/models/delivery_response.rb
@@ -1,58 +1,32 @@
 class DeliveryResponse < ApplicationRecord
   belongs_to :mail_queue
 
-  # 各 mail_queue_id ごとのレコード群が次の条件を満たす場合に、
-  # その各レコード群の最新のレコードをリストで返します。
-  # - 最古の responded_at 時刻から time_limit_string 時間がまだ経過していない
-  # - 最新のレコードの status が 4xx である
+  # mail_queue_id ごとのグループについて、
+  # - 最初の配信試行（最古の responded_at）から time_limit_seconds 以内であり
+  # - 最新の配信結果の status が 4xx である
+  # ものについて、その最新の DeliveryResponse の ActiveRecord::Relation を返します。
   #
-  # 別の言い方： DeliveryResponse を mail_queue_id ごとのグループにした時、
-  # それぞれの最新のレコードの status が 4xx であるものを集めたリストを結果として得ますが、
-  # ただしそれぞれのグループの最古のレコードの responded_at 時刻から time_limit_string 時間が経過していた場合は、
-  # 結果のリストには含めません。
-  #
-  # 例）たとえば time_limit_string = '72:00:00' の場合、
-  # ある mail_queue_id に関係するレスポンスのうちで最古のものの、
-  # その responded_at の時刻から 72 時間以上を経過していた場合、
-  # その mail_queue_id に関連するデータは結果に含まれません。
-  #
-  # TODO:
-  #   DB と Rails とのタイムゾーンを合わせなければいけません。
-  #   また NOW() を使うと、 rspec で時刻を固定するテストが実施できなくなるので、使わないようにします。
-  #   タイムゾーンは次の前提です：
-  #   - DB のタイムゾーン = システムのタイムゾーン = JST
-  #   - Rails のタイムゾーン(ActiveRecord 含む) = JST
-  #
-  # WARN:
-  #   - SQL の中の HAVING... のところで、 #strftime を使っています。
-  #     これについては #to_fs(:db) を使わないでください。 UTC の時刻になってしまいます。
-  def self.last_status_4xx_within_time_limit(time_limit_string = '72:00:00') # 初期値 72時間=3日間
-    DeliveryResponse.find_by_sql(<<-SQL2
-      SELECT * FROM delivery_responses AS T0
+  # 返される DeliveryResponse のリストにひもづく各 MailQueue は、
+  # まだ再送信猶予時間内にあり、再送信を試みる候補となります。
+  def self.last_status_4xx_within_time_limit(time_limit_seconds = 72.hours)
+    raise ArgumentError, 'time_limit_seconds must be positive' if time_limit_seconds.to_i <= 0
+
+    boundary_time = Time.current - time_limit_seconds.to_i
+
+    DeliveryResponse.find_by_sql([<<-SQL2, boundary_time])
+      SELECT T0.* FROM delivery_responses AS T0
       INNER JOIN (
         SELECT
           mail_queue_id,
-          MAX(responded_at) AS latest
+          MAX(responded_at) AS latest,
+          MIN(responded_at) AS earliest
         FROM delivery_responses
         GROUP BY mail_queue_id
-      ) AS T3
-      ON T0.responded_at = T3.latest AND T0.mail_queue_id = T3.mail_queue_id
-      WHERE T0.mail_queue_id IN (
-        SELECT T1.mail_queue_id FROM delivery_responses AS T1
-          INNER JOIN (
-            SELECT
-              id,
-              mail_queue_id,
-              ADDTIME(MIN(responded_at), '#{time_limit_string}') AS limittime
-            FROM delivery_responses
-            GROUP BY mail_queue_id
-            HAVING "#{Time.current.strftime("%Y-%m-%d %H:%M:%S")}" < limittime
-          ) AS T2
-          ON T1.mail_queue_id = T2.mail_queue_id
-        GROUP BY T1.mail_queue_id
-      )
-      AND T0.status LIKE "4__"
+      ) AS agg
+        ON T0.mail_queue_id = agg.mail_queue_id
+        AND T0.responded_at = agg.latest
+      WHERE T0.status LIKE "4__"
+        AND agg.earliest > ?
     SQL2
-    )
   end
 end

--- a/app/services/verbena/delivery_service.rb
+++ b/app/services/verbena/delivery_service.rb
@@ -30,6 +30,8 @@ module Verbena
     # 変更不可
     attr_reader :session_id
 
+    DEFAULT_TIME_LIMIT = '72:00:00'.freeze
+
     # インスタンスの識別子を発行します。
     # MailQueue のレコードはこの値によって処理対象であることの印が付けられます。
     def self.issue_session_id
@@ -65,9 +67,9 @@ module Verbena
     # 指定した session_id による配送処理の結果がステータス 4xx である対象の MailQueue のレコードを、
     # 再処理可能な状態にリセットします。
     # ただしその session_id による最古の配送時刻から timelimit 時間が経過している場合は処理しません。
-    def prepare_to_retry_for_session(timelimit = '72:00:00')
+    def prepare_to_retry_for_session(timelimit = DEFAULT_TIME_LIMIT)
       reset_mail_queues(
-        DeliveryResponse.last_status_4xx_within_time_limit(timelimit.to_s).map(&:mail_queue_id)
+        DeliveryResponse.last_status_4xx_within_time_limit(parse_timelimit_seconds(timelimit)).map(&:mail_queue_id)
       )
     end
 
@@ -216,6 +218,22 @@ module Verbena
     def json_logging_enabled?
       # Detect by checking formatter class
       Rails.logger.formatter.is_a?(::Verbena::JsonLogFormatter) rescue false
+    end
+
+    def parse_timelimit_seconds(timelimit)
+      str = timelimit.presence || DEFAULT_TIME_LIMIT
+      unless str.is_a?(String)
+        raise ArgumentError, 'timelimit must be a HH:MM:SS string'
+      end
+
+      m = /\A(\d+):([0-5]\d):([0-5]\d)\z/.match(str)
+      raise ArgumentError, 'timelimit must be a HH:MM:SS string' unless m
+
+      hours, minutes, seconds = m.captures.map(&:to_i)
+      total_seconds = hours * 3600 + minutes * 60 + seconds
+      raise ArgumentError, 'timelimit must be positive' if total_seconds <= 0
+
+      total_seconds
     end
   end
 end

--- a/spec/models/delivery_response_spec.rb
+++ b/spec/models/delivery_response_spec.rb
@@ -9,6 +9,12 @@ RSpec.describe DeliveryResponse, type: :model do
 
   describe 'クラスメソッド' do
     describe '#last_status_4xx_within_time_limit' do
+      describe '入力検証' do
+        it '0以下の値は例外を投げる' do
+          expect { DeliveryResponse.last_status_4xx_within_time_limit(0) }.to raise_error(ArgumentError)
+        end
+      end
+
       let!(:current_time) { Time.zone.parse('2023-08-10 10:00:00 +0900') }
 
       before do
@@ -51,7 +57,7 @@ RSpec.describe DeliveryResponse, type: :model do
             include_context 'メールキュー 4 のレスポンスが 2 つ = 9 時間前、 6 時間前の順にステータス [400, 250] である場合'
 
             context 'パラメータに、すべての配送レスポンスのうちで最古の時刻が含まれる値を渡す場合' do
-              let!(:timelimit) { '72:00:00' }
+              let!(:timelimit) { 72.hours }
 
               it 'メールキュー 1 と 3 それぞれの、最新のレスポンスのレコードだけのリストが得られる' do
                 is_expected.to eq [dr1b.id, dr3c.id]
@@ -65,7 +71,7 @@ RSpec.describe DeliveryResponse, type: :model do
             include_context 'メールキュー 1 のレスポンスが 2 つ = 6 時間前、 3 時間前の順にステータス [400, 400] である場合'
 
             context 'パラメータに 05:59:00 を渡す場合' do
-              let!(:timelimit) { '05:59:00' }
+              let!(:timelimit) { 5.hours + 59.minutes }
 
               it '空のリストが得られる' do
                 is_expected.to be_empty
@@ -73,7 +79,7 @@ RSpec.describe DeliveryResponse, type: :model do
             end
 
             context 'パラメータに 06:00:00 を渡す場合' do
-              let!(:timelimit) { '06:00:00' }
+              let!(:timelimit) { 6.hours }
 
               it '空のリストが得られる' do
                 is_expected.to be_empty
@@ -81,13 +87,53 @@ RSpec.describe DeliveryResponse, type: :model do
             end
 
             context 'パラメータに 06:00:01 を渡す場合' do
-              let!(:timelimit) { '06:00:01' }
+              let!(:timelimit) { 6.hours + 1.second }
 
               it 'メールキュー 1 の最新のレスポンスのレコードだけのリストが得られる' do
                 is_expected.to eq [dr1b.id]
               end
             end
           end
+        end
+      end
+
+      describe '追加のエッジケース' do
+        let!(:mq) { FactoryBot.create(:mail_queue) }
+        let!(:now) { Time.zone.parse('2023-08-10 10:00:00 +0900') }
+
+        before { travel_to now }
+
+        it 'nilを渡すと例外' do
+          expect { described_class.last_status_4xx_within_time_limit(nil) }.to raise_error(ArgumentError)
+        end
+
+        it '文字列を渡すと例外' do
+          expect { described_class.last_status_4xx_within_time_limit('abc') }.to raise_error(ArgumentError)
+        end
+
+        it 'floatを渡すと小数点切り捨てで動作（ActiveSupport::Duration仕様）' do
+          FactoryBot.create(:delivery_response, mail_queue: mq, status: '400', responded_at: now - 3.hours)
+          expect(described_class.last_status_4xx_within_time_limit(3.9.hours).map(&:mail_queue_id)).to eq [mq.id]
+        end
+
+        it 'レスポンスが1件だけの場合も正しく返す' do
+          dr = FactoryBot.create(:delivery_response, mail_queue: mq, status: '400', responded_at: now - 1.hour)
+          expect(described_class.last_status_4xx_within_time_limit(2.hours)).to include dr
+        end
+
+        it '全て期限外の場合は空' do
+          FactoryBot.create(:delivery_response, mail_queue: mq, status: '400', responded_at: now - 10.hours)
+          expect(described_class.last_status_4xx_within_time_limit(1.hour)).to be_empty
+        end
+
+        it '4xx以外のステータスは除外される' do
+          FactoryBot.create(:delivery_response, mail_queue: mq, status: '500', responded_at: now - 1.hour)
+          expect(described_class.last_status_4xx_within_time_limit(2.hours)).to be_empty
+        end
+
+        it '境界値: 最古responded_at==boundary_timeは含まれない' do
+          FactoryBot.create(:delivery_response, mail_queue: mq, status: '400', responded_at: now - 2.hours)
+          expect(described_class.last_status_4xx_within_time_limit(2.hours)).to be_empty
         end
       end
     end

--- a/spec/services/delivery_service_spec.rb
+++ b/spec/services/delivery_service_spec.rb
@@ -198,6 +198,18 @@ RSpec.describe Verbena::DeliveryService, type: :service do
               instance.prepare_to_retry_for_session('03:00:00')
             end
           end
+
+          context '引数 time_limit に不正な形式を渡す場合' do
+            it 'ArgumentError を投げる' do
+              expect { instance.prepare_to_retry_for_session('DROP TABLE delivery_responses;') }.to raise_error(ArgumentError)
+            end
+          end
+
+          context '引数 time_limit に 00:00:00 を渡す場合' do
+            it 'ArgumentError を投げる' do
+              expect { instance.prepare_to_retry_for_session('00:00:00') }.to raise_error(ArgumentError)
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
#8 の対応です。
主な修正点は値を SQL に直接埋め込んでいる箇所の修正です。
またこの際ついでなので、引数のところの仕様も見直し、またSQLもGPT に見直してもらいました。

---

This pull request refactors and improves the handling of time limits for retrying mail deliveries, focusing on clearer parameter handling, stricter input validation, and improved test coverage for edge cases. The main change is to use seconds (as integer or ActiveSupport::Duration) instead of a string for time limits in the core logic, while still allowing string input at the service layer with proper parsing and validation.

**Core logic and validation improvements:**

* Refactored `DeliveryResponse.last_status_4xx_within_time_limit` to accept time limits in seconds (integer or ActiveSupport::Duration) instead of a string, with strict validation to raise an error for non-positive values. The SQL logic was updated for clarity and correctness.
* Added a new `parse_timelimit_seconds` method in `DeliveryService` to validate and convert 'HH:MM:SS' strings to seconds, raising an error for invalid formats or non-positive values.

**Service layer adjustments:**

* Updated `prepare_to_retry_for_session` in `DeliveryService` to use the new parsing method, ensuring time limits are consistently validated and converted before use. Also defined a `DEFAULT_TIME_LIMIT` constant for default values. [[1]](diffhunk://#diff-66b409fa39d6a56d6d6c8b6a236071f7262eb1cf7d72b50c748c698974256d15R33-R34) [[2]](diffhunk://#diff-66b409fa39d6a56d6d6c8b6a236071f7262eb1cf7d72b50c748c698974256d15L68-R72)

**Test enhancements:**

* Expanded model specs for `DeliveryResponse` to cover input validation, edge cases (such as nil, invalid strings, floats, and boundary values), and correct filtering logic. [[1]](diffhunk://#diff-72f99939b44b24b3b5109255daa5ecdac475294f03147d39a679003378911dafR12-R17) [[2]](diffhunk://#diff-72f99939b44b24b3b5109255daa5ecdac475294f03147d39a679003378911dafL54-R60) [[3]](diffhunk://#diff-72f99939b44b24b3b5109255daa5ecdac475294f03147d39a679003378911dafL68-R90) [[4]](diffhunk://#diff-72f99939b44b24b3b5109255daa5ecdac475294f03147d39a679003378911dafR99-R138)
* Added service specs to verify that invalid or zero time limit strings raise `ArgumentError` in `prepare_to_retry_for_session`.