### PR TITLE
メソッド名のタイポ修正 config_for_in_batchs → config_for_in_batches

### DIFF
--- a/app/helpers/delivery_helper.rb
+++ b/app/helpers/delivery_helper.rb
@@ -48,7 +48,7 @@ module DeliveryHelper
   end
 
   # 処理対象のレコードを分割して処理するための in_batches に渡すオプションパラメタを返します。
-  def config_for_in_batchs
+  def config_for_in_batches
     Verbena::Settings.in_batches_config
   end
 

--- a/app/services/verbena/delivery_service.rb
+++ b/app/services/verbena/delivery_service.rb
@@ -102,7 +102,7 @@ module Verbena
     # 通常は claim されているレコードがない状況から始めることになるため、
     # このメソッドではなくいずれかの perform_by_... メソッドを利用します。
     def perform
-      MailQueue.claimed(session_id).in_batches(**config_for_in_batchs) do |rel|
+      MailQueue.claimed(session_id).in_batches(**config_for_in_batches) do |rel|
         Parallel.each(rel.all, config_for_parallel) do |mail_queue|
           perform_one(mail_queue)
         end


### PR DESCRIPTION
#11 の対応で、単に typo を直すものです。
