### PR TITLE
delivery.rake の改善

### DIFF
--- a/app/services/verbena/delivery_service.rb
+++ b/app/services/verbena/delivery_service.rb
@@ -54,6 +54,15 @@ module Verbena
       @session_id = options[:session_id].presence || self.class.issue_session_id
     end
 
+    # ファクトリ：メンテナンス用途などで明示的に session_id を与えてインスタンス化する場合に使用します。
+    def self.with_session(session_id, **options)
+      if session_id.blank?
+        raise ArgumentError, 'session_id is required for with_session'
+      end
+
+      new(options.merge(session_id: session_id))
+    end
+
     # 一度も処理されていないレコードの中で、
     # 現在時刻がタイマー時刻を経過しているレコードを対象にした送信処理を実行します。
     def perform_by_timer

--- a/lib/tasks/verbena/delivery.rake
+++ b/lib/tasks/verbena/delivery.rake
@@ -5,8 +5,8 @@ namespace :verbena do
       begin
         Verbena::DeliveryService.new.perform_by_timer
       rescue => e
-        $stderr.puts "ERROR: by_timer failed: \\#{e.class}: \\#{e.message}"
-        exit 1
+        $stderr.puts "ERROR: by_timer failed: #{e.class}: #{e.message}"
+        Kernel.exit(1)
       end
     end
 
@@ -15,8 +15,8 @@ namespace :verbena do
       begin
         Verbena::DeliveryService.new.perform_by_mail_queue_id(args.extras)
       rescue => e
-        $stderr.puts "ERROR: by_ids failed: \\#{e.class}: \\#{e.message}"
-        exit 1
+        $stderr.puts "ERROR: by_ids failed: #{e.class}: #{e.message}"
+        Kernel.exit(1)
       end
     end
 
@@ -24,10 +24,10 @@ namespace :verbena do
     task :prepare_retry, [:session_id] => :environment do |_task, args|
       begin
         count = Verbena::DeliveryService.with_session(args[:session_id]).prepare_to_retry_for_session(args.extras.first)
-        puts "prepare_retry: reset \\#{count} mail_queues for session_id=\\#{args[:session_id]}"
+        puts "prepare_retry: reset #{count} mail_queues for session_id=#{args[:session_id]}"
       rescue => e
-        $stderr.puts "ERROR: prepare_retry failed: \\#{e.class}: \\#{e.message}"
-        exit 1
+        $stderr.puts "ERROR: prepare_retry failed: #{e.class}: #{e.message}"
+        Kernel.exit(1)
       end
     end
 
@@ -35,10 +35,10 @@ namespace :verbena do
     task :reset_undelivered, [:session_id] => :environment do |_task, args|
       begin
         count = Verbena::DeliveryService.with_session(args[:session_id]).prepare_to_retry_undelivered
-        puts "reset_undelivered: reset \\#{count} mail_queues for session_id=\\#{args[:session_id]}"
+        puts "reset_undelivered: reset #{count} mail_queues for session_id=#{args[:session_id]}"
       rescue => e
-        $stderr.puts "ERROR: reset_undelivered failed: \\#{e.class}: \\#{e.message}"
-        exit 1
+        $stderr.puts "ERROR: reset_undelivered failed: #{e.class}: #{e.message}"
+        Kernel.exit(1)
       end
     end
   end

--- a/lib/tasks/verbena/delivery.rake
+++ b/lib/tasks/verbena/delivery.rake
@@ -2,23 +2,44 @@ namespace :verbena do
   namespace :delivery do
     desc 'mail_queue のメッセージを配送する(タイマー制御)'
     task by_timer: :environment  do |_task, args|
-      Verbena::DeliveryService.new.perform_by_timer
+      begin
+        Verbena::DeliveryService.new.perform_by_timer
+      rescue => e
+        $stderr.puts "ERROR: by_timer failed: \\#{e.class}: \\#{e.message}"
+        exit 1
+      end
     end
 
     desc 'mail_queue のメッセージを配送する(ID指定)'
     task by_ids: :environment  do |_task, args|
-      Verbena::DeliveryService.new.perform_by_mail_queue_id(args.extras)
+      begin
+        Verbena::DeliveryService.new.perform_by_mail_queue_id(args.extras)
+      rescue => e
+        $stderr.puts "ERROR: by_ids failed: \\#{e.class}: \\#{e.message}"
+        exit 1
+      end
     end
 
     desc 'session_id の処理のうちで直近の配送がステータス4xxであったメッセージを再送可能状態にする'
     task :prepare_retry, [:session_id] => :environment do |_task, args|
-      timelimit = args.extras.first
-      Verbena::DeliveryService.new(args).prepare_to_retry_for_session(timelimit)
+      begin
+        count = Verbena::DeliveryService.with_session(args[:session_id]).prepare_to_retry_for_session(args.extras.first)
+        puts "prepare_retry: reset \\#{count} mail_queues for session_id=\\#{args[:session_id]}"
+      rescue => e
+        $stderr.puts "ERROR: prepare_retry failed: \\#{e.class}: \\#{e.message}"
+        exit 1
+      end
     end
 
     desc 'session_id の処理のうちで配送結果が無いメッセージを再送可能状態にする'
     task :reset_undelivered, [:session_id] => :environment do |_task, args|
-      Verbena::DeliveryService.new(args).prepare_to_retry_undelivered
+      begin
+        count = Verbena::DeliveryService.with_session(args[:session_id]).prepare_to_retry_undelivered
+        puts "reset_undelivered: reset \\#{count} mail_queues for session_id=\\#{args[:session_id]}"
+      rescue => e
+        $stderr.puts "ERROR: reset_undelivered failed: \\#{e.class}: \\#{e.message}"
+        exit 1
+      end
     end
   end
 end

--- a/spec/services/verbena/delivery_service_spec.rb
+++ b/spec/services/verbena/delivery_service_spec.rb
@@ -83,6 +83,20 @@ RSpec.describe Verbena::DeliveryService, type: :service do
         expect(buf.uniq.length).to eq 1000
       end
     end
+
+    describe '.with_session' do
+      it 'raises ArgumentError if session_id is blank' do
+        expect { described_class.with_session(nil) }.to raise_error(ArgumentError)
+        expect { described_class.with_session('') }.to raise_error(ArgumentError)
+        expect { described_class.with_session('   ') }.to raise_error(ArgumentError)
+      end
+
+      it 'returns an instance with the given session_id' do
+        svc = described_class.with_session('my-session-123')
+        expect(svc).to be_a(described_class)
+        expect(svc.session_id).to eq('my-session-123')
+      end
+    end
   end
 
   describe 'インスタンスメソッド' do

--- a/spec/tasks/verbena/delivery_rake_spec.rb
+++ b/spec/tasks/verbena/delivery_rake_spec.rb
@@ -1,0 +1,91 @@
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe 'verbena:delivery rake tasks' do
+  let!(:current_time) { Time.zone.parse('2023-10-23 16:00:00') }
+
+  before do
+    travel_to current_time
+    # Recreate Rake.application per example to avoid task definitions leaking
+    # between examples (Rake.application is global). This ensures each example
+    # loads a fresh task set and `task.reenable` works reliably.
+    Rake.application = Rake::Application.new
+    load Rails.root.join('lib', 'tasks', 'verbena', 'delivery.rake')
+    Rake::Task.define_task(:environment)
+  end
+
+  after do
+    travel_back
+  end
+
+  describe 'verbena:delivery:prepare_retry' do
+    let(:task) { Rake::Task['verbena:delivery:prepare_retry'] }
+
+    before do
+      task.reenable
+    end
+
+    context 'when session_id is missing' do
+      it 'prints an error to stderr and calls exit(1) without killing the process' do
+        task.reenable
+        allow(Kernel).to receive(:exit)  # stub to prevent process termination
+        expect { task.invoke(nil) }.to output(/ERROR: prepare_retry failed/).to_stderr
+        expect(Kernel).to have_received(:exit).with(1)
+      end
+    end
+
+    context 'when valid session_id and timelimit provided' do
+      let!(:mq1) { FactoryBot.create(:mail_queue, :touched, session_id: 'sess') }
+      let!(:mq2) { FactoryBot.create(:mail_queue, :touched, session_id: 'sess') }
+      let!(:mq3) { FactoryBot.create(:mail_queue, :touched, session_id: 'sess') }
+      let!(:mq4) { FactoryBot.create(:mail_queue, :touched, session_id: 'sess') }
+
+      before do
+        FactoryBot.create(:delivery_response, mail_queue_id: mq1.id, responded_at: current_time - 2.hour, status: '400')
+        FactoryBot.create(:delivery_response, mail_queue_id: mq2.id, responded_at: current_time - 3.hour, status: '400')
+        FactoryBot.create(:delivery_response, mail_queue_id: mq2.id, responded_at: current_time - 2.hour, status: '250')
+        FactoryBot.create(:delivery_response, mail_queue_id: mq3.id, responded_at: current_time - 2.hour, status: '250')
+        FactoryBot.create(:delivery_response, mail_queue_id: mq4.id, responded_at: current_time - 4.hour, status: '400')
+      end
+
+      it 'prints the number of reset mail_queues to stdout' do
+        task.reenable
+        # Use timelimit 03:00:00 so only mq1 is within window
+        expect { task.invoke('sess', '03:00:00') }.to output(/prepare_retry: reset 1 mail_queues for session_id=sess/).to_stdout
+      end
+    end
+  end
+
+  describe 'verbena:delivery:reset_undelivered' do
+    let(:task) { Rake::Task['verbena:delivery:reset_undelivered'] }
+
+    before do
+      task.reenable
+    end
+
+    context 'when session_id is missing' do
+      it 'prints an error to stderr and calls exit(1) without killing the process' do
+        task.reenable
+        allow(Kernel).to receive(:exit)  # stub to prevent process termination
+        expect { task.invoke(nil) }.to output(/ERROR: reset_undelivered failed/).to_stderr
+        expect(Kernel).to have_received(:exit).with(1)
+      end
+    end
+
+    context 'when valid session_id provided' do
+      let!(:mq1) { FactoryBot.create(:mail_queue, session_id: 'something') }
+      let!(:mq2) { FactoryBot.create(:mail_queue, session_id: 'something') }
+      let!(:mq3) { FactoryBot.create(:mail_queue, session_id: 'other') }
+
+      before do
+        # mq1 has no delivery_responses (should be reset)
+        mq2.delivery_responses.create!
+      end
+
+      it 'prints the number of reset mail_queues to stdout' do
+        task.reenable
+        expect { task.invoke('something') }.to output(/reset_undelivered: reset 1 mail_queues for session_id=something/).to_stdout
+      end
+    end
+  end
+end


### PR DESCRIPTION
#2 の対応です。

機能的なものではなく、ソースコードの品質や安定性の向上のための改善になります。

---

This pull request improves the robustness and testability of the `verbena:delivery` Rake tasks by adding error handling, introducing a factory method for explicit session-based service instantiation, and providing comprehensive RSpec tests for the Rake tasks. The main changes can be grouped as follows:

**Rake Task Improvements:**

* Added error handling to all `verbena:delivery` Rake tasks, so failures are logged to stderr and the process exits with code 1. Success messages are output with counts for relevant tasks.

**Service Enhancements:**

* Introduced the `.with_session` factory method to `Verbena::DeliveryService` for explicit instantiation with a given `session_id`, raising an `ArgumentError` if the session ID is blank.

**Testing:**

* Added RSpec tests for the `.with_session` method, verifying correct behavior and error handling.
* Added comprehensive RSpec tests for the `verbena:delivery:prepare_retry` and `verbena:delivery:reset_undelivered` Rake tasks, including both error and success scenarios.
