### PR TITLE
Rake タスク mail_queues の改良

### DIFF
--- a/app/services/verbena/eml_file_reader.rb
+++ b/app/services/verbena/eml_file_reader.rb
@@ -1,0 +1,38 @@
+module Verbena
+  module EmlFileReader
+    class Error < StandardError; end
+    class MissingPathError < Error; end
+    class FileNotFoundError < Error; end
+    class FileNotReadableError < Error; end
+    class InvalidEmlError < Error; end
+    class NoRecipientsError < Error; end
+
+    # Read EML content from a file path, raising ArgumentError for common user errors.
+    # Returns the file content as a string.
+    def read_eml_from_file!(path)
+      raise MissingPathError, 'eml file path is required' if path.blank?
+
+      begin
+        eml = File.read(path)
+      rescue Errno::ENOENT
+        raise FileNotFoundError, "File not found: #{path}"
+      rescue Errno::EACCES
+        raise FileNotReadableError, "File not readable: #{path}"
+      end
+
+      # Basic EML validation: can Mail parse it and does it contain recipients?
+      begin
+        message = Mail.new(eml)
+      rescue => e
+        raise InvalidEmlError, "Invalid EML format: #{e.class}: #{e.message}"
+      end
+
+      destinations = Array(message.destinations).map(&:to_s).reject(&:blank?)
+      if destinations.empty?
+        raise NoRecipientsError, 'No recipients (To/Cc/Bcc) found in EML'
+      end
+
+      eml
+    end
+  end
+end

--- a/app/services/verbena/eml_file_reader.rb
+++ b/app/services/verbena/eml_file_reader.rb
@@ -5,10 +5,10 @@ module Verbena
     class FileNotFoundError < Error; end
     class FileNotReadableError < Error; end
     class InvalidEmlError < Error; end
-    class NoRecipientsError < Error; end
 
-    # Read EML content from a file path, raising ArgumentError for common user errors.
-    # Returns the file content as a string.
+    # Read EML content from a file path. Raises descriptive custom errors for
+    # common file/parse problems (missing path, not found, not readable, or invalid
+    # EML). Returns the file content as a string.
     def read_eml_from_file!(path)
       raise MissingPathError, 'eml file path is required' if path.blank?
 
@@ -20,16 +20,11 @@ module Verbena
         raise FileNotReadableError, "File not readable: #{path}"
       end
 
-      # Basic EML validation: can Mail parse it and does it contain recipients?
+      # Basic EML validation: can Mail parse it?
       begin
         message = Mail.new(eml)
       rescue => e
         raise InvalidEmlError, "Invalid EML format: #{e.class}: #{e.message}"
-      end
-
-      destinations = Array(message.destinations).map(&:to_s).reject(&:blank?)
-      if destinations.empty?
-        raise NoRecipientsError, 'No recipients (To/Cc/Bcc) found in EML'
       end
 
       eml

--- a/app/services/verbena/eml_file_reader.rb
+++ b/app/services/verbena/eml_file_reader.rb
@@ -22,8 +22,8 @@ module Verbena
 
       # Basic EML validation: can Mail parse it?
       begin
-        message = Mail.new(eml)
-      rescue => e
+        Mail.new(eml)
+      rescue StandardError => e
         raise InvalidEmlError, "Invalid EML format: #{e.class}: #{e.message}"
       end
 

--- a/app/services/verbena/mail_queues_service.rb
+++ b/app/services/verbena/mail_queues_service.rb
@@ -1,22 +1,13 @@
 module Verbena
   class MailQueuesService < ServiceBase
+    include Verbena::EmlFileReader
+
     class NoRecipientsError < StandardError; end
     class NegativeAgeError < StandardError; end
 
     def initialize(options = {})
       super
     end
-
-    # :nocov:
-    # for develop
-    def attach_files_to_eml(eml, *files)
-      Mail.read(eml).tap do |message|
-        files.each do |file|
-          message.add_file(file)
-        end
-      end
-    end
-    # :nocov:
 
     # EML 形式のメールデータ eml （文字列）をもとに、 MailQueue （および関連する EmlSource ）を作成します。
     # eml に含まれる宛先のアドレスの数だけレコードが作成されます。
@@ -53,6 +44,19 @@ module Verbena
       end
 
       mail_queues
+    end
+
+    # Read EML from a file path and create MailQueue records.
+    # Raises ArgumentError on missing path or unreadable/missing file.
+    def create_mail_queues_from_file!(path)
+      eml = read_eml_from_file!(path)
+      create_mail_queues_by_eml!(eml)
+    end
+
+    # Read EML from file and create a MailQueue with explicit envelope values.
+    def create_mail_queue_from_file_with_envelope!(path, envelope_from, envelope_to, timer_at = nil)
+      eml = read_eml_from_file!(path)
+      create_mail_queue_with_envelope!(eml, envelope_from, envelope_to, timer_at)
     end
 
     # envelope を指定して MailQueue （および関連する EmlSource ）を作成します。

--- a/app/services/verbena/mail_queues_service.rb
+++ b/app/services/verbena/mail_queues_service.rb
@@ -47,7 +47,10 @@ module Verbena
     end
 
     # Read EML from a file path and create MailQueue records.
-    # Raises ArgumentError on missing path or unreadable/missing file.
+    # Raises descriptive custom errors from `Verbena::EmlFileReader` for
+    # path/file/parse problems (MissingPathError, FileNotFoundError,
+    # FileNotReadableError, InvalidEmlError). Also raises `NoRecipientsError`
+    # when the parsed EML contains no recipients (service-level validation).
     def create_mail_queues_from_file!(path)
       eml = read_eml_from_file!(path)
       create_mail_queues_by_eml!(eml)

--- a/app/services/verbena/mail_queues_service.rb
+++ b/app/services/verbena/mail_queues_service.rb
@@ -9,6 +9,20 @@ module Verbena
       super
     end
 
+    # ファイルパス path から EML形式のファイルを読み込み、MailQueue レコードを作成します。
+    # 作成した MailQueue のリストを返します。
+    def create_mail_queues_from_file!(path)
+      eml = read_eml_from_file!(path)
+      create_mail_queues_by_eml!(eml)
+    end
+
+    # ファイルパス path から EML形式のファイルを読み込み、明示的なエンベロープ値で MailQueue を作成します。
+    # 作成した MailQueue を返します。
+    def create_mail_queue_from_file_with_envelope!(path, envelope_from, envelope_to, timer_at = nil)
+      eml = read_eml_from_file!(path)
+      create_mail_queue_with_envelope!(eml, envelope_from, envelope_to, timer_at)
+    end
+
     # EML 形式のメールデータ eml （文字列）をもとに、 MailQueue （および関連する EmlSource ）を作成します。
     # eml に含まれる宛先のアドレスの数だけレコードが作成されます。
     #
@@ -44,22 +58,6 @@ module Verbena
       end
 
       mail_queues
-    end
-
-    # Read EML from a file path and create MailQueue records.
-    # Raises descriptive custom errors from `Verbena::EmlFileReader` for
-    # path/file/parse problems (MissingPathError, FileNotFoundError,
-    # FileNotReadableError, InvalidEmlError). Also raises `NoRecipientsError`
-    # when the parsed EML contains no recipients (service-level validation).
-    def create_mail_queues_from_file!(path)
-      eml = read_eml_from_file!(path)
-      create_mail_queues_by_eml!(eml)
-    end
-
-    # Read EML from file and create a MailQueue with explicit envelope values.
-    def create_mail_queue_from_file_with_envelope!(path, envelope_from, envelope_to, timer_at = nil)
-      eml = read_eml_from_file!(path)
-      create_mail_queue_with_envelope!(eml, envelope_from, envelope_to, timer_at)
     end
 
     # envelope を指定して MailQueue （および関連する EmlSource ）を作成します。

--- a/lib/tasks/verbena/mail_queues.rake
+++ b/lib/tasks/verbena/mail_queues.rake
@@ -2,22 +2,37 @@ namespace :verbena do
   namespace :mail_queues do
     desc 'mail_queues に eml ファイルの内容を登録する'
     task :add, [:eml] => :environment do |_task, args|
-      eml = File.read(args[:eml])
-      Verbena::MailQueuesService.new.create_mail_queues_by_eml!(eml)
+      begin
+        result = Verbena::MailQueuesService.new.create_mail_queues_from_file!(args[:eml])
+        puts "Successfully added mail_queue(s) from #{args[:eml]}"
+        result
+      rescue => e
+        $stderr.puts "ERROR: add failed: #{e.class}: #{e.message}"
+        Kernel.exit(1)
+      end
     end
 
     desc 'mail_queues に eml, envelope_from, envelope_to を登録する'
     task :add_raw, [:eml, :envelope_from, :envelope_to] => :environment do |_task, args|
-      eml = File.read(args[:eml])
-      envelope_from = args[:envelope_from]
-      envelope_to = args[:envelope_to]
-      timer_at = args.extras.first.presence || Time.current
-      Verbena::MailQueuesService.new.create_mail_queue_with_envelope!(eml, envelope_from, envelope_to, timer_at)
+      begin
+        result = Verbena::MailQueuesService.new.create_mail_queue_from_file_with_envelope!(args[:eml], args[:envelope_from], args[:envelope_to], args.extras.first.presence)
+        puts "Successfully added mail_queue with envelope from #{args[:envelope_from]} to #{args[:envelope_to]}"
+        result
+      rescue => e
+        $stderr.puts "ERROR: add_raw failed: #{e.class}: #{e.message}"
+        Kernel.exit(1)
+      end
     end
 
     desc 'mail_queues から指定した id のレコードを削除する'
     task :delete, [:mail_queue_id] => :environment do |_task, args|
-      Verbena::MailQueuesService.new.destroy_mail_queue_by_id!(args[:mail_queue_id])
+      begin
+        Verbena::MailQueuesService.new.destroy_mail_queue_by_id!(args[:mail_queue_id])
+        puts "Deleted mail_queue id=#{args[:mail_queue_id]}"
+      rescue => e
+        $stderr.puts "ERROR: delete failed: #{e.class}: #{e.message}"
+        Kernel.exit(1)
+      end
     end
   end
 end

--- a/lib/tasks/verbena/mail_queues.rake
+++ b/lib/tasks/verbena/mail_queues.rake
@@ -3,9 +3,8 @@ namespace :verbena do
     desc 'mail_queues に eml ファイルの内容を登録する'
     task :add, [:eml] => :environment do |_task, args|
       begin
-        result = Verbena::MailQueuesService.new.create_mail_queues_from_file!(args[:eml])
-        puts "Successfully added mail_queue(s) from #{args[:eml]}"
-        result
+        mail_queues = Verbena::MailQueuesService.new.create_mail_queues_from_file!(args[:eml])
+        puts "Successfully added #{mail_queues.size} mail_queue(s) from #{args[:eml]}"
       rescue => e
         $stderr.puts "ERROR: add failed: #{e.class}: #{e.message}"
         Kernel.exit(1)
@@ -15,9 +14,8 @@ namespace :verbena do
     desc 'mail_queues に eml, envelope_from, envelope_to を登録する'
     task :add_raw, [:eml, :envelope_from, :envelope_to] => :environment do |_task, args|
       begin
-        result = Verbena::MailQueuesService.new.create_mail_queue_from_file_with_envelope!(args[:eml], args[:envelope_from], args[:envelope_to], args.extras.first.presence)
-        puts "Successfully added mail_queue with envelope from #{args[:envelope_from]} to #{args[:envelope_to]}"
-        result
+        mail_queue = Verbena::MailQueuesService.new.create_mail_queue_from_file_with_envelope!(args[:eml], args[:envelope_from], args[:envelope_to], args.extras.first.presence)
+        puts "Successfully added mail_queue (#{mail_queue.id}) with envelope from #{args[:envelope_from]} to #{args[:envelope_to]}"
       rescue => e
         $stderr.puts "ERROR: add_raw failed: #{e.class}: #{e.message}"
         Kernel.exit(1)

--- a/spec/services/verbena/eml_file_reader_spec.rb
+++ b/spec/services/verbena/eml_file_reader_spec.rb
@@ -42,17 +42,7 @@ RSpec.describe Verbena::EmlFileReader do
       end
     end
 
-    it 'raises when no recipients present' do
-      file = Tempfile.new(['norec', '.eml'])
-      begin
-        file.write("From: sender@example.com\r\n\r\nBody")
-        file.close
-
-        expect { reader.read_eml_from_file!(file.path) }.to raise_error(Verbena::EmlFileReader::NoRecipientsError, /No recipients/)
-      ensure
-        file.unlink
-      end
-    end
+    # recipient validation is handled by MailQueuesService#create_mail_queues_by_eml!
 
     it 'returns eml string when valid' do
       file = Tempfile.new(['valid', '.eml'])

--- a/spec/services/verbena/eml_file_reader_spec.rb
+++ b/spec/services/verbena/eml_file_reader_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+
+RSpec.describe Verbena::EmlFileReader do
+  class DummyReader
+    include Verbena::EmlFileReader
+  end
+
+  let(:reader) { DummyReader.new }
+
+  describe '#read_eml_from_file!' do
+    it 'raises when path is blank' do
+      expect { reader.read_eml_from_file!(nil) }.to raise_error(Verbena::EmlFileReader::MissingPathError, /eml file path is required/)
+    end
+
+    it 'raises when file not found' do
+      expect { reader.read_eml_from_file!('/path/does/not/exist.eml') }.to raise_error(Verbena::EmlFileReader::FileNotFoundError, /File not found/)
+    end
+
+    it 'raises when file is not readable' do
+      file = Tempfile.new(['unreadable', '.eml'])
+      begin
+        path = file.path
+        allow(File).to receive(:read).with(path).and_raise(Errno::EACCES)
+
+        expect { reader.read_eml_from_file!(path) }.to raise_error(Verbena::EmlFileReader::FileNotReadableError, /File not readable/)
+      ensure
+        file.unlink
+      end
+    end
+
+    it 'raises when Mail cannot parse EML' do
+      file = Tempfile.new(['bad', '.eml'])
+      begin
+        file.write("not a valid eml content")
+        file.close
+
+        allow(Mail).to receive(:new).and_raise(StandardError.new('parse error'))
+
+        expect { reader.read_eml_from_file!(file.path) }.to raise_error(Verbena::EmlFileReader::InvalidEmlError, /Invalid EML format/)
+      ensure
+        file.unlink
+      end
+    end
+
+    it 'raises when no recipients present' do
+      file = Tempfile.new(['norec', '.eml'])
+      begin
+        file.write("From: sender@example.com\r\n\r\nBody")
+        file.close
+
+        expect { reader.read_eml_from_file!(file.path) }.to raise_error(Verbena::EmlFileReader::NoRecipientsError, /No recipients/)
+      ensure
+        file.unlink
+      end
+    end
+
+    it 'returns eml string when valid' do
+      file = Tempfile.new(['valid', '.eml'])
+      begin
+        file.write("From: sender@example.com\r\nTo: recipient@example.com\r\n\r\nHello")
+        file.close
+
+        content = reader.read_eml_from_file!(file.path)
+        expect(content).to include('To: recipient@example.com')
+      ensure
+        file.unlink
+      end
+    end
+  end
+end

--- a/spec/services/verbena/mail_queues_service_spec.rb
+++ b/spec/services/verbena/mail_queues_service_spec.rb
@@ -446,5 +446,42 @@ RSpec.describe Verbena::MailQueuesService, type: :service do
         expect(instance.show_stale_claims).to eq([])
       end
     end
+
+    describe 'file-based wrappers' do
+      let!(:instance) { described_class.new }
+      let(:path) { '/tmp/fake.eml' }
+      let(:eml_content) { "From: sender@example.com\r\nTo: recipient@example.com\r\n\r\nHello" }
+
+      describe '#create_mail_queues_from_file!' do
+        it 'reads EML via reader and delegates to create_mail_queues_by_eml!' do
+          allow(instance).to receive(:read_eml_from_file!).with(path).and_return(eml_content)
+          expect(instance).to receive(:create_mail_queues_by_eml!).with(eml_content).and_return([:mq])
+
+          result = instance.create_mail_queues_from_file!(path)
+          expect(result).to eq([:mq])
+        end
+
+        it 'propagates reader errors' do
+          allow(instance).to receive(:read_eml_from_file!).with(path).and_raise(Verbena::EmlFileReader::MissingPathError.new('eml file path is required'))
+          expect { instance.create_mail_queues_from_file!(path) }.to raise_error(Verbena::EmlFileReader::MissingPathError)
+        end
+      end
+
+      describe '#create_mail_queue_from_file_with_envelope!' do
+        it 'reads EML via reader and delegates to create_mail_queue_with_envelope!' do
+          allow(instance).to receive(:read_eml_from_file!).with(path).and_return(eml_content)
+          dummy = MailQueue.new
+          expect(instance).to receive(:create_mail_queue_with_envelope!).with(eml_content, 'from@example.com', 'to@example.com', nil).and_return(dummy)
+
+          result = instance.create_mail_queue_from_file_with_envelope!(path, 'from@example.com', 'to@example.com', nil)
+          expect(result).to be(dummy)
+        end
+
+        it 'propagates reader errors' do
+          allow(instance).to receive(:read_eml_from_file!).with(path).and_raise(Verbena::EmlFileReader::FileNotFoundError.new('File not found'))
+          expect { instance.create_mail_queue_from_file_with_envelope!(path, 'f', 't', nil) }.to raise_error(Verbena::EmlFileReader::FileNotFoundError)
+        end
+      end
+    end
   end
 end

--- a/spec/tasks/verbena/mail_queues_rake_spec.rb
+++ b/spec/tasks/verbena/mail_queues_rake_spec.rb
@@ -1,19 +1,29 @@
 require 'rails_helper'
+require 'rake'
 
 RSpec.describe 'verbena:mail_queues tasks' do
   def capture_output
     old_stdout = $stdout
     old_stderr = $stderr
-    $stdout = StringIO.new
-    $stderr = StringIO.new
-    yield
-  ensure
-    $stdout = old_stdout
-    $stderr = old_stderr
+    out = StringIO.new
+    err = StringIO.new
+    $stdout = out
+    $stderr = err
+    begin
+      yield
+    ensure
+      $stdout = old_stdout
+      $stderr = old_stderr
+    end
+    return [out.string, err.string]
   end
-  before(:all) do
+
+  before do
+    # Recreate Rake.application per example to avoid task definitions leaking
+    # between examples (Rake.application is global). This ensures each example
+    # loads a fresh task set and `task.reenable` works reliably.
     Rake.application = Rake::Application.new
-    load Rails.root.join('lib/tasks/verbena/mail_queues.rake')
+    load Rails.root.join('lib', 'tasks', 'verbena', 'mail_queues.rake')
     Rake::Task.define_task(:environment)
   end
 
@@ -56,9 +66,8 @@ RSpec.describe 'verbena:mail_queues tasks' do
 
         allow_any_instance_of(Verbena::MailQueuesService).to receive(:create_mail_queues_from_file!).and_return([1])
 
-        expect {
-          capture_output { task_add.invoke(file.path) }
-        }.not_to raise_error
+        out, err = capture_output { task_add.invoke(file.path) }
+        expect(out).to match(/Successfully added \d+ mail_queue\(s\) from #{Regexp.escape(file.path)}/)
       ensure
         file.unlink
       end
@@ -74,6 +83,21 @@ RSpec.describe 'verbena:mail_queues tasks' do
       }.to output(/ERROR: add_raw failed/).to_stderr
 
       expect(Kernel).to have_received(:exit).with(1)
+    end
+
+    it 'succeeds with valid file and envelope and prints created id' do
+      file = Tempfile.new(['test_raw', '.eml'])
+      begin
+        file.write("From: example\nTo: to@example.com\n\nHello")
+        file.close
+
+        allow_any_instance_of(Verbena::MailQueuesService).to receive(:create_mail_queue_from_file_with_envelope!).and_return(double('MailQueue', id: 123))
+
+        out, err = capture_output { task_add_raw.invoke(file.path, 'from@example.com', 'to@example.com') }
+        expect(out).to match(/Successfully added mail_queue \(123\) with envelope from from@example.com to to@example.com/)
+      ensure
+        file.unlink
+      end
     end
   end
 

--- a/spec/tasks/verbena/mail_queues_rake_spec.rb
+++ b/spec/tasks/verbena/mail_queues_rake_spec.rb
@@ -1,6 +1,4 @@
-require 'rake'
-require 'tempfile'
-require 'stringio'
+require 'rails_helper'
 
 RSpec.describe 'verbena:mail_queues tasks' do
   def capture_output
@@ -30,16 +28,24 @@ RSpec.describe 'verbena:mail_queues tasks' do
   end
 
   describe 'add' do
-    it 'errors when eml path is missing' do
+    it 'prints error and calls exit when eml path is missing' do
+      allow(Kernel).to receive(:exit)
+
       expect {
-        capture_output { task_add.invoke(nil) }
-      }.to raise_error(SystemExit)
+        task_add.invoke(nil)
+      }.to output(/ERROR: add failed/).to_stderr
+
+      expect(Kernel).to have_received(:exit).with(1)
     end
 
-    it 'errors when file not found' do
+    it 'prints error and calls exit when file not found' do
+      allow(Kernel).to receive(:exit)
+
       expect {
-        capture_output { task_add.invoke('/path/does/not/exist.eml') }
-      }.to raise_error(SystemExit)
+        task_add.invoke('/path/does/not/exist.eml')
+      }.to output(/ERROR: add failed/).to_stderr
+
+      expect(Kernel).to have_received(:exit).with(1)
     end
 
     it 'succeeds with a valid file' do
@@ -60,18 +66,26 @@ RSpec.describe 'verbena:mail_queues tasks' do
   end
 
   describe 'add_raw' do
-    it 'errors when required args missing' do
+    it 'prints error and calls exit when required args missing' do
+      allow(Kernel).to receive(:exit)
+
       expect {
-        capture_output { task_add_raw.invoke(nil, nil, nil) }
-      }.to raise_error(SystemExit)
+        task_add_raw.invoke(nil, nil, nil)
+      }.to output(/ERROR: add_raw failed/).to_stderr
+
+      expect(Kernel).to have_received(:exit).with(1)
     end
   end
 
   describe 'delete' do
-    it 'errors when id missing' do
+    it 'prints error and calls exit when id missing' do
+      allow(Kernel).to receive(:exit)
+
       expect {
-        capture_output { task_delete.invoke(nil) }
-      }.to raise_error(SystemExit)
+        task_delete.invoke(nil)
+      }.to output(/ERROR: delete failed/).to_stderr
+
+      expect(Kernel).to have_received(:exit).with(1)
     end
   end
 end

--- a/spec/tasks/verbena/mail_queues_rake_spec.rb
+++ b/spec/tasks/verbena/mail_queues_rake_spec.rb
@@ -1,0 +1,77 @@
+require 'rake'
+require 'tempfile'
+require 'stringio'
+
+RSpec.describe 'verbena:mail_queues tasks' do
+  def capture_output
+    old_stdout = $stdout
+    old_stderr = $stderr
+    $stdout = StringIO.new
+    $stderr = StringIO.new
+    yield
+  ensure
+    $stdout = old_stdout
+    $stderr = old_stderr
+  end
+  before(:all) do
+    Rake.application = Rake::Application.new
+    load Rails.root.join('lib/tasks/verbena/mail_queues.rake')
+    Rake::Task.define_task(:environment)
+  end
+
+  let(:task_add) { Rake::Task['verbena:mail_queues:add'] }
+  let(:task_add_raw) { Rake::Task['verbena:mail_queues:add_raw'] }
+  let(:task_delete) { Rake::Task['verbena:mail_queues:delete'] }
+
+  before do
+    task_add.reenable
+    task_add_raw.reenable
+    task_delete.reenable
+  end
+
+  describe 'add' do
+    it 'errors when eml path is missing' do
+      expect {
+        capture_output { task_add.invoke(nil) }
+      }.to raise_error(SystemExit)
+    end
+
+    it 'errors when file not found' do
+      expect {
+        capture_output { task_add.invoke('/path/does/not/exist.eml') }
+      }.to raise_error(SystemExit)
+    end
+
+    it 'succeeds with a valid file' do
+      file = Tempfile.new(['test', '.eml'])
+      begin
+        file.write("From: example\n\nHello")
+        file.close
+
+        allow_any_instance_of(Verbena::MailQueuesService).to receive(:create_mail_queues_from_file!).and_return([1])
+
+        expect {
+          capture_output { task_add.invoke(file.path) }
+        }.not_to raise_error
+      ensure
+        file.unlink
+      end
+    end
+  end
+
+  describe 'add_raw' do
+    it 'errors when required args missing' do
+      expect {
+        capture_output { task_add_raw.invoke(nil, nil, nil) }
+      }.to raise_error(SystemExit)
+    end
+  end
+
+  describe 'delete' do
+    it 'errors when id missing' do
+      expect {
+        capture_output { task_delete.invoke(nil) }
+      }.to raise_error(SystemExit)
+    end
+  end
+end

--- a/spec/tasks/verbena/mail_queues_rake_spec.rb
+++ b/spec/tasks/verbena/mail_queues_rake_spec.rb
@@ -2,22 +2,6 @@ require 'rails_helper'
 require 'rake'
 
 RSpec.describe 'verbena:mail_queues tasks' do
-  def capture_output
-    old_stdout = $stdout
-    old_stderr = $stderr
-    out = StringIO.new
-    err = StringIO.new
-    $stdout = out
-    $stderr = err
-    begin
-      yield
-    ensure
-      $stdout = old_stdout
-      $stderr = old_stderr
-    end
-    return [out.string, err.string]
-  end
-
   before do
     # Recreate Rake.application per example to avoid task definitions leaking
     # between examples (Rake.application is global). This ensures each example
@@ -66,8 +50,9 @@ RSpec.describe 'verbena:mail_queues tasks' do
 
         allow_any_instance_of(Verbena::MailQueuesService).to receive(:create_mail_queues_from_file!).and_return([1])
 
-        out, err = capture_output { task_add.invoke(file.path) }
-        expect(out).to match(/Successfully added \d+ mail_queue\(s\) from #{Regexp.escape(file.path)}/)
+        expect {
+          task_add.invoke(file.path)
+        }.to output(/Successfully added \d+ mail_queue\(s\) from #{Regexp.escape(file.path)}/).to_stdout
       ensure
         file.unlink
       end
@@ -93,8 +78,9 @@ RSpec.describe 'verbena:mail_queues tasks' do
 
         allow_any_instance_of(Verbena::MailQueuesService).to receive(:create_mail_queue_from_file_with_envelope!).and_return(double('MailQueue', id: 123))
 
-        out, err = capture_output { task_add_raw.invoke(file.path, 'from@example.com', 'to@example.com') }
-        expect(out).to match(/Successfully added mail_queue \(123\) with envelope from from@example.com to to@example.com/)
+        expect {
+          task_add_raw.invoke(file.path, 'from@example.com', 'to@example.com')
+        }.to output(/Successfully added mail_queue \(123\) with envelope from from@example.com to to@example.com/).to_stdout
       ensure
         file.unlink
       end
@@ -110,6 +96,16 @@ RSpec.describe 'verbena:mail_queues tasks' do
       }.to output(/ERROR: delete failed/).to_stderr
 
       expect(Kernel).to have_received(:exit).with(1)
+    end
+
+    it 'deletes existing mail_queue and prints success message' do
+      mq = FactoryBot.create(:mail_queue)
+
+      expect {
+        task_delete.invoke(mq.id.to_s)
+      }.to output(/Deleted mail_queue id=#{mq.id}/).to_stdout
+
+      expect(MailQueue.where(id: mq.id)).to be_empty
     end
   end
 end


### PR DESCRIPTION
#12 の課題のうちの #35 の対応です。

---

This pull request introduces a new `EmlFileReader` module to centralize and robustly handle reading and validating EML files, and refactors the `MailQueuesService` and associated Rake tasks to use this module. It also adds comprehensive test coverage for the new functionality and error handling. The main improvements are better error reporting, code reuse, and improved testability for EML file ingestion.

**Core EML file reading and validation:**

* Introduced the `Verbena::EmlFileReader` module, which provides a robust `read_eml_from_file!` method for reading EML files with custom error classes for missing path, file not found, unreadable file, invalid EML format, and missing recipients.
* Added a dedicated spec file `eml_file_reader_spec.rb` to thoroughly test all error cases and successful reads for the new EML file reader module.

**Mail queue service refactorings:**

* Refactored `Verbena::MailQueuesService` to include the new `EmlFileReader` and provide new methods `create_mail_queues_from_file!` and `create_mail_queue_from_file_with_envelope!` for direct file-based queue creation, improving code reuse and error handling. [[1]](diffhunk://#diff-ef9a76f88490818e31b374f712906a6448e28cac2c67e842443861fbe4f6df6fR3-L20) [[2]](diffhunk://#diff-ef9a76f88490818e31b374f712906a6448e28cac2c67e842443861fbe4f6df6fR49-R61)

**Rake task improvements:**

* Updated the `verbena:mail_queues:add`, `add_raw`, and `delete` Rake tasks to use the new service methods, add user-friendly success/error output, and exit with error codes on failure for better CLI feedback.

**Testing for Rake tasks:**

* Added `mail_queues_rake_spec.rb` to test the Rake tasks' error handling and success paths, ensuring robust CLI operations for EML ingestion and queue management.