### PR TITLE
Rake タスク cleanup の改良

### DIFF
--- a/app/services/verbena/service_base.rb
+++ b/app/services/verbena/service_base.rb
@@ -40,5 +40,17 @@ module Verbena
       # Detect by checking formatter class
       Rails.logger.formatter.is_a?(::Verbena::JsonLogFormatter) rescue false
     end
+
+    # Coerce various input values to boolean using Rails casting rules.
+    # Useful for web params and rake args ("1", "true", "t", "yes", etc.).
+    def self.truthy?(val)
+      @boolean_type ||= ActiveModel::Type::Boolean.new
+      !!@boolean_type.cast(val)
+    end
+
+    # Instance-level convenience delegating to the class method
+    def truthy?(val)
+      self.class.truthy?(val)
+    end
   end
 end

--- a/app/services/verbena/service_base.rb
+++ b/app/services/verbena/service_base.rb
@@ -44,8 +44,8 @@ module Verbena
     # Coerce various input values to boolean using Rails casting rules.
     # Useful for web params and rake args ("1", "true", "t", "yes", etc.).
     def self.truthy?(val)
-      @boolean_type ||= ActiveModel::Type::Boolean.new
-      !!@boolean_type.cast(val)
+      # ActiveModel::Type::Boolean.new is lightweight; instantiate per-call
+      !!ActiveModel::Type::Boolean.new.cast(val)
     end
 
     # Instance-level convenience delegating to the class method

--- a/lib/tasks/verbena/claim.rake
+++ b/lib/tasks/verbena/claim.rake
@@ -4,7 +4,7 @@ namespace :verbena do
     task :release_stale, [:older_than_hours, :dry] => :environment do |_task, args|
       begin
         older_than_hours = Verbena::MailQueuesService.normalize_hours_arg(args[:older_than_hours])
-        dry_run = truthy?(args[:dry])
+        dry_run = Verbena::ServiceBase.truthy?(args[:dry])
 
         service = Verbena::MailQueuesService.new
         stale_count = service.release_stale_claims(older_than_hours: older_than_hours, dry_run: dry_run)
@@ -45,14 +45,6 @@ namespace :verbena do
         Kernel.exit(1)
       end
     end
-  end
-
-  # Rake helper methods (local to this file)
-  BOOLEAN_TYPE ||= ActiveModel::Type::Boolean.new
-
-  def truthy?(val)
-    # Rails-native boolean casting: true => 1,true,t,on,yes | false => 0,false,f,off,no
-    !!BOOLEAN_TYPE.cast(val)
   end
 
   # Format seconds as human-readable string.

--- a/lib/tasks/verbena/cleanup.rake
+++ b/lib/tasks/verbena/cleanup.rake
@@ -2,38 +2,58 @@ namespace :verbena do
   namespace :cleanup do
     desc '配送処理後、一ヶ月以上を経過した mail_queues と関連レコードを削除する'
     task :monthly, [:dry] => :environment do |_task, args|
-      service = Verbena::CleanupService.monthly(dry_run: truthy?(args[:dry]))
-      report(service.cleanup)
+      begin
+        service = Verbena::CleanupService.monthly(dry_run: Verbena::ServiceBase.truthy?(args[:dry]))
+        report(service.cleanup)
+      rescue StandardError => e
+        $stderr.puts "ERROR: monthly failed: #{e.class}: #{e.message}"
+        Kernel.exit(1)
+      end
     end
 
     desc '配送処理後、一週以上を経過した mail_queues と関連レコードを削除する'
     task :weekly, [:dry] => :environment do |_task, args|
-      service = Verbena::CleanupService.weekly(dry_run: truthy?(args[:dry]))
-      report(service.cleanup)
+      begin
+        service = Verbena::CleanupService.weekly(dry_run: Verbena::ServiceBase.truthy?(args[:dry]))
+        report(service.cleanup)
+      rescue StandardError => e
+        $stderr.puts "ERROR: weekly failed: #{e.class}: #{e.message}"
+        Kernel.exit(1)
+      end
     end
 
     desc '配送処理後、一日以上を経過した mail_queues と関連レコードを削除する'
     task :daily, [:dry] => :environment do |_task, args|
-      service = Verbena::CleanupService.daily(dry_run: truthy?(args[:dry]))
-      report(service.cleanup)
+      begin
+        service = Verbena::CleanupService.daily(dry_run: Verbena::ServiceBase.truthy?(args[:dry]))
+        report(service.cleanup)
+      rescue StandardError => e
+        $stderr.puts "ERROR: daily failed: #{e.class}: #{e.message}"
+        Kernel.exit(1)
+      end
     end
 
     desc '配送処理が済んでいる mail_queues と関連レコードを削除する'
     task :now, [:dry] => :environment do |_task, args|
-      service = Verbena::CleanupService.new(dry_run: truthy?(args[:dry]))
-      report(service.cleanup)
+      begin
+        service = Verbena::CleanupService.new(dry_run: Verbena::ServiceBase.truthy?(args[:dry]))
+        report(service.cleanup)
+      rescue StandardError => e
+        $stderr.puts "ERROR: now failed: #{e.class}: #{e.message}"
+        Kernel.exit(1)
+      end
     end
 
     desc 'TTL 設定（VERBENA_CLEANUP_TTL_DAYS）に基づいてクリーンアップを実行（dry オプション対応）'
     task :by_ttl, [:dry] => :environment do |_task, args|
-      service = Verbena::CleanupService.by_ttl(dry_run: truthy?(args[:dry]))
-      report(service.cleanup)
+      begin
+        service = Verbena::CleanupService.by_ttl(dry_run: Verbena::ServiceBase.truthy?(args[:dry]))
+        report(service.cleanup)
+      rescue StandardError => e
+        $stderr.puts "ERROR: by_ttl failed: #{e.class}: #{e.message}"
+        Kernel.exit(1)
+      end
     end
-  end
-
-  # Rake helper methods (local to this file)
-  def truthy?(val)
-    %w[1 true yes y t].include?(val.to_s.strip.downcase)
   end
 
   def report(result)

--- a/spec/services/verbena/service_base_spec.rb
+++ b/spec/services/verbena/service_base_spec.rb
@@ -67,4 +67,20 @@ RSpec.describe Verbena::ServiceBase, type: :service do
       expect(service.json_logging_enabled?).to be false
     end
   end
+
+  describe '.truthy? / #truthy?' do
+    it 'returns true for common truthy values' do
+      %w[1 true yes y t on n no].each do |v|
+        expect(described_class.truthy?(v)).to be true
+        expect(service.truthy?(v)).to be true
+      end
+    end
+
+    it 'returns false for common falsy values' do
+      [nil, '', '0', 'false', 'off', 'f'].each do |v|
+        expect(described_class.truthy?(v)).to be false
+        expect(service.truthy?(v)).to be false
+      end
+    end
+  end
 end

--- a/spec/tasks/verbena/cleanup_rake_spec.rb
+++ b/spec/tasks/verbena/cleanup_rake_spec.rb
@@ -1,0 +1,87 @@
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe 'verbena:cleanup tasks' do
+  before do
+    Rake.application = Rake::Application.new
+    load Rails.root.join('lib', 'tasks', 'verbena', 'cleanup.rake')
+    Rake::Task.define_task(:environment)
+  end
+
+  let(:task_monthly) { Rake::Task['verbena:cleanup:monthly'] }
+  let(:task_weekly)  { Rake::Task['verbena:cleanup:weekly'] }
+  let(:task_daily)   { Rake::Task['verbena:cleanup:daily'] }
+  let(:task_now)     { Rake::Task['verbena:cleanup:now'] }
+  let(:task_by_ttl)  { Rake::Task['verbena:cleanup:by_ttl'] }
+
+  before do
+    task_monthly.reenable
+    task_weekly.reenable
+    task_daily.reenable
+    task_now.reenable
+    task_by_ttl.reenable
+  end
+
+  shared_examples 'cleanup error handling' do |task|
+    it 'prints error and calls exit when service raises' do
+      allow(Kernel).to receive(:exit)
+      allow_any_instance_of(Verbena::CleanupService).to receive(:cleanup).and_raise(StandardError, 'test error')
+
+      expect {
+        send(task).invoke
+      }.to output(/ERROR: .* failed: StandardError: test error/).to_stderr
+
+      expect(Kernel).to have_received(:exit).with(1)
+    end
+  end
+
+  describe 'monthly' do
+    include_examples 'cleanup error handling', :task_monthly
+    it 'prints result on success' do
+      allow_any_instance_of(Verbena::CleanupService).to receive(:cleanup).and_return({ mail_queues: 2, eml_sources: 1 })
+      expect {
+        task_monthly.invoke
+      }.to output(/mail_queues=2 eml_sources=1/).to_stdout
+    end
+  end
+
+  describe 'weekly' do
+    include_examples 'cleanup error handling', :task_weekly
+    it 'prints result on success' do
+      allow_any_instance_of(Verbena::CleanupService).to receive(:cleanup).and_return({ mail_queues: 3, eml_sources: 0 })
+      expect {
+        task_weekly.invoke
+      }.to output(/mail_queues=3 eml_sources=0/).to_stdout
+    end
+  end
+
+  describe 'daily' do
+    include_examples 'cleanup error handling', :task_daily
+    it 'prints result on success' do
+      allow_any_instance_of(Verbena::CleanupService).to receive(:cleanup).and_return({ mail_queues: 1, eml_sources: 2 })
+      expect {
+        task_daily.invoke
+      }.to output(/mail_queues=1 eml_sources=2/).to_stdout
+    end
+  end
+
+  describe 'now' do
+    include_examples 'cleanup error handling', :task_now
+    it 'prints result on success' do
+      allow_any_instance_of(Verbena::CleanupService).to receive(:cleanup).and_return({ mail_queues: 5, eml_sources: 4 })
+      expect {
+        task_now.invoke
+      }.to output(/mail_queues=5 eml_sources=4/).to_stdout
+    end
+  end
+
+  describe 'by_ttl' do
+    include_examples 'cleanup error handling', :task_by_ttl
+    it 'prints result on success' do
+      allow_any_instance_of(Verbena::CleanupService).to receive(:cleanup).and_return({ mail_queues: 7, eml_sources: 8 })
+      expect {
+        task_by_ttl.invoke
+      }.to output(/mail_queues=7 eml_sources=8/).to_stdout
+    end
+  end
+end

--- a/spec/tasks/verbena/cleanup_rake_spec.rb
+++ b/spec/tasks/verbena/cleanup_rake_spec.rb
@@ -24,14 +24,21 @@ RSpec.describe 'verbena:cleanup tasks' do
 
   shared_examples 'cleanup error handling' do |task|
     it 'prints error and calls exit when service raises' do
-      allow(Kernel).to receive(:exit)
       allow_any_instance_of(Verbena::CleanupService).to receive(:cleanup).and_raise(StandardError, 'test error')
 
+      stderr_output = StringIO.new
       expect {
-        send(task).invoke
-      }.to output(/ERROR: .* failed: StandardError: test error/).to_stderr
+        begin
+          $stderr = stderr_output
+          send(task).invoke
+        ensure
+          $stderr = STDERR
+        end
+      }.to raise_error(SystemExit) { |ex|
+        expect(ex.status).to eq(1)
+      }
 
-      expect(Kernel).to have_received(:exit).with(1)
+      expect(stderr_output.string).to match(/ERROR: .* failed: StandardError: test error/)
     end
   end
 

--- a/spec/tasks/verbena/cleanup_rake_spec.rb
+++ b/spec/tasks/verbena/cleanup_rake_spec.rb
@@ -22,9 +22,11 @@ RSpec.describe 'verbena:cleanup tasks' do
     task_by_ttl.reenable
   end
 
-  shared_examples 'cleanup error handling' do |task|
-    it 'prints error and calls exit when service raises' do
-      allow_any_instance_of(Verbena::CleanupService).to receive(:cleanup).and_raise(StandardError, 'test error')
+  shared_examples 'cleanup error handling' do |task, factory|
+    it 'prints error and exits when service raises' do
+      service = instance_double(Verbena::CleanupService)
+      allow(Verbena::CleanupService).to receive(factory).and_return(service)
+      allow(service).to receive(:cleanup).and_raise(StandardError, 'test error')
 
       stderr_output = StringIO.new
       expect {
@@ -43,9 +45,12 @@ RSpec.describe 'verbena:cleanup tasks' do
   end
 
   describe 'monthly' do
-    include_examples 'cleanup error handling', :task_monthly
+    include_examples 'cleanup error handling', :task_monthly, :monthly
     it 'prints result on success' do
-      allow_any_instance_of(Verbena::CleanupService).to receive(:cleanup).and_return({ mail_queues: 2, eml_sources: 1 })
+      service = instance_double(Verbena::CleanupService)
+      allow(Verbena::CleanupService).to receive(:monthly).and_return(service)
+      allow(service).to receive(:cleanup).and_return({ mail_queues: 2, eml_sources: 1 })
+
       expect {
         task_monthly.invoke
       }.to output(/mail_queues=2 eml_sources=1/).to_stdout
@@ -53,9 +58,12 @@ RSpec.describe 'verbena:cleanup tasks' do
   end
 
   describe 'weekly' do
-    include_examples 'cleanup error handling', :task_weekly
+    include_examples 'cleanup error handling', :task_weekly, :weekly
     it 'prints result on success' do
-      allow_any_instance_of(Verbena::CleanupService).to receive(:cleanup).and_return({ mail_queues: 3, eml_sources: 0 })
+      service = instance_double(Verbena::CleanupService)
+      allow(Verbena::CleanupService).to receive(:weekly).and_return(service)
+      allow(service).to receive(:cleanup).and_return({ mail_queues: 3, eml_sources: 0 })
+
       expect {
         task_weekly.invoke
       }.to output(/mail_queues=3 eml_sources=0/).to_stdout
@@ -63,9 +71,12 @@ RSpec.describe 'verbena:cleanup tasks' do
   end
 
   describe 'daily' do
-    include_examples 'cleanup error handling', :task_daily
+    include_examples 'cleanup error handling', :task_daily, :daily
     it 'prints result on success' do
-      allow_any_instance_of(Verbena::CleanupService).to receive(:cleanup).and_return({ mail_queues: 1, eml_sources: 2 })
+      service = instance_double(Verbena::CleanupService)
+      allow(Verbena::CleanupService).to receive(:daily).and_return(service)
+      allow(service).to receive(:cleanup).and_return({ mail_queues: 1, eml_sources: 2 })
+
       expect {
         task_daily.invoke
       }.to output(/mail_queues=1 eml_sources=2/).to_stdout
@@ -73,9 +84,12 @@ RSpec.describe 'verbena:cleanup tasks' do
   end
 
   describe 'now' do
-    include_examples 'cleanup error handling', :task_now
+    include_examples 'cleanup error handling', :task_now, :new
     it 'prints result on success' do
-      allow_any_instance_of(Verbena::CleanupService).to receive(:cleanup).and_return({ mail_queues: 5, eml_sources: 4 })
+      service = instance_double(Verbena::CleanupService)
+      allow(Verbena::CleanupService).to receive(:new).and_return(service)
+      allow(service).to receive(:cleanup).and_return({ mail_queues: 5, eml_sources: 4 })
+
       expect {
         task_now.invoke
       }.to output(/mail_queues=5 eml_sources=4/).to_stdout
@@ -83,9 +97,12 @@ RSpec.describe 'verbena:cleanup tasks' do
   end
 
   describe 'by_ttl' do
-    include_examples 'cleanup error handling', :task_by_ttl
+    include_examples 'cleanup error handling', :task_by_ttl, :by_ttl
     it 'prints result on success' do
-      allow_any_instance_of(Verbena::CleanupService).to receive(:cleanup).and_return({ mail_queues: 7, eml_sources: 8 })
+      service = instance_double(Verbena::CleanupService)
+      allow(Verbena::CleanupService).to receive(:by_ttl).and_return(service)
+      allow(service).to receive(:cleanup).and_return({ mail_queues: 7, eml_sources: 8 })
+
       expect {
         task_by_ttl.invoke
       }.to output(/mail_queues=7 eml_sources=8/).to_stdout


### PR DESCRIPTION
#12 の課題のうちの #37 の対応です。

This pull request refactors the way boolean arguments are handled in Rake tasks and adds robust error handling and test coverage for the `verbena:cleanup` tasks. The most significant changes are the introduction of a centralized boolean coercion method, the removal of duplicated helper methods, improved error handling in cleanup tasks, and the addition of comprehensive RSpec tests for these tasks.

**Refactoring and Centralization:**

* Added a new `.truthy?` class method and an instance method to `Verbena::ServiceBase` for consistent, Rails-native boolean coercion across the codebase. This replaces various ad-hoc implementations of boolean parsing.
* Updated all usages of `truthy?` in `lib/tasks/verbena/claim.rake` and `lib/tasks/verbena/cleanup.rake` to use the new centralized `Verbena::ServiceBase.truthy?` method, and removed the now-redundant local helper methods. [[1]](diffhunk://#diff-286d7914d2c9df59708fe85ab4250317863897d95f968e7d60716255deb77348L7-R7) [[2]](diffhunk://#diff-286d7914d2c9df59708fe85ab4250317863897d95f968e7d60716255deb77348L50-L57) [[3]](diffhunk://#diff-abe4d196f818b52b821c81d88ce57c2610e6c3dff89358fcc1a52953693149bcL5-L36)

**Error Handling Improvements:**

* Wrapped each cleanup Rake task (`monthly`, `weekly`, `daily`, `now`, `by_ttl`) in a `begin/rescue` block to catch exceptions, print a clear error message to stderr, and exit with a non-zero status code on failure.

**Testing Enhancements:**

* Added a new RSpec file `spec/tasks/verbena/cleanup_rake_spec.rb` that tests both successful and error scenarios for all cleanup Rake tasks. This includes verifying correct output and error handling behavior.