### PR TITLE
Rake タスク tokens の改良

### DIFF
--- a/app/services/verbena/token_service.rb
+++ b/app/services/verbena/token_service.rb
@@ -2,6 +2,21 @@ module Verbena
   class TokenService < ServiceBase
     DEFAULT_BATCH_SIZE = 1000
 
+    # Returns the number of tokens that would be revoked (dry-run count).
+    def expired_count
+      revoke_expired(dry_run: true)
+    end
+
+    # Perform the revocation and return the number revoked. This is a
+    # clearer, explicit destructive API for callers that actually want to
+    # mutate state (rake tasks, operators, etc.). Internally delegates to
+    # the existing `revoke_expired` implementation.
+    def revoke_expired!
+      revoke_expired(dry_run: false)
+    end
+
+    private
+
     # Revoke expired tokens that are not yet revoked.
     # Returns the number of tokens revoked (or would be revoked in dry run).
     #
@@ -10,11 +25,11 @@ module Verbena
     # For this application, the tokens table is small, so batch processing is
     # optional and overhead is minimal.
     def revoke_expired(dry_run: false, batch_size: DEFAULT_BATCH_SIZE)
-      relation = Token.expired
-      return relation.count if dry_run
+      rel = expired_relation
+      return rel.count if dry_run
 
       revoked_count = 0
-      relation.find_in_batches(batch_size: batch_size) do |batch|
+      rel.find_in_batches(batch_size: batch_size) do |batch|
         batch.each do |tok|
           begin
             tok.revoke!(Time.current)
@@ -33,6 +48,13 @@ module Verbena
         end
       end
       revoked_count
+    end
+
+    # Centralize how we build the relation of tokens we intend to operate on.
+    # This ensures `expired_count` and revocation use identical selection
+    # logic and avoids divergence if the criteria change.
+    def expired_relation
+      Token.expired
     end
   end
 end

--- a/lib/tasks/verbena/tokens.rake
+++ b/lib/tasks/verbena/tokens.rake
@@ -1,18 +1,22 @@
 namespace :verbena do
   namespace :tokens do
     desc 'Revoke expired tokens (sets revoked_at). Usage: rake verbena:tokens:revoke_expired[dry]'
-    task :revoke_expired, [:mode] => :environment do |t, args|
-      mode = args[:mode].to_s
-      dry_run = mode == 'dry'
+    task :revoke_expired, [:dry] => :environment do |_task, args|
+      begin
+        dry_run = Verbena::ServiceBase.truthy?(args[:dry])
 
-      service = Verbena::TokenService.new
+        service = Verbena::TokenService.new
 
-      if dry_run
-        count = service.revoke_expired(dry_run: true)
-        puts "[verbena:tokens:revoke_expired] Dry run: #{count} tokens would be revoked"
-      else
-        revoked_count = service.revoke_expired(dry_run: false)
-        puts "[verbena:tokens:revoke_expired] Revoked #{revoked_count} tokens"
+        if dry_run
+          count = service.expired_count
+          puts "[verbena:tokens:revoke_expired] Dry run: #{count} tokens would be revoked"
+        else
+          revoked_count = service.revoke_expired!
+          puts "[verbena:tokens:revoke_expired] Revoked #{revoked_count} tokens"
+        end
+      rescue StandardError => e
+        $stderr.puts "ERROR: revoke_expired failed: #{e.class}: #{e.message}"
+        Kernel.exit(1)
       end
     end
   end

--- a/spec/services/verbena/token_service_spec.rb
+++ b/spec/services/verbena/token_service_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Verbena::TokenService, type: :service do
 
     context 'dry run' do
       it 'returns count and does not revoke' do
-        expect(service.revoke_expired(dry_run: true)).to eq(1)
+        expect(service.expired_count).to eq(1)
         expect(expired_token.reload.revoked_at).to be_nil
         expect(active_token.reload.revoked_at).to be_nil
       end
@@ -18,7 +18,7 @@ RSpec.describe Verbena::TokenService, type: :service do
 
     context 'execute' do
       it 'revokes only expired tokens and returns count' do
-        expect(service.revoke_expired(dry_run: false)).to eq(1)
+        expect(service.revoke_expired!).to eq(1)
         expect(expired_token.reload.revoked_at).not_to be_nil
         expect(active_token.reload.revoked_at).to be_nil
       end
@@ -29,10 +29,10 @@ RSpec.describe Verbena::TokenService, type: :service do
 
       it 'does not count or revoke already-revoked tokens' do
         # dry run should still only count the non-revoked expired token
-        expect(service.revoke_expired(dry_run: true)).to eq(1)
+        expect(service.expired_count).to eq(1)
 
         # execute should revoke only the non-revoked expired token
-        result = service.revoke_expired(dry_run: false)
+        result = service.revoke_expired!
         expect(result).to eq(1)
 
         # ensure the already-revoked token remains revoked and untouched
@@ -54,7 +54,7 @@ RSpec.describe Verbena::TokenService, type: :service do
         allow(Token).to receive(:expired).and_return(relation)
         allow(relation).to receive(:find_in_batches).and_yield([token_error, token_success, expired_token])
 
-        result = service.revoke_expired(dry_run: false)
+        result = service.revoke_expired!
 
         # The service should return the number of tokens it actually revoked.
         actual_revoked_count = [token_error, token_success, expired_token].count { |t| t.reload.revoked_at.present? }

--- a/spec/tasks/verbena/tokens_rake_spec.rb
+++ b/spec/tasks/verbena/tokens_rake_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe 'verbena:tokens tasks' do
+  before do
+    Rake.application = Rake::Application.new
+    load Rails.root.join('lib', 'tasks', 'verbena', 'tokens.rake')
+    Rake::Task.define_task(:environment)
+  end
+
+  let(:task_revoke) { Rake::Task['verbena:tokens:revoke_expired'] }
+
+  before do
+    task_revoke.reenable
+  end
+
+  describe 'revoke_expired' do
+    it 'prints dry run summary when dry flag is truthy' do
+      allow_any_instance_of(Verbena::TokenService).to receive(:expired_count).and_return(7)
+
+      expect {
+        task_revoke.invoke('1')
+      }.to output(/Dry run: 7 tokens would be revoked/).to_stdout
+    end
+
+    it 'prints revoked count on success' do
+      allow_any_instance_of(Verbena::TokenService).to receive(:revoke_expired!).and_return(3)
+
+      expect {
+        task_revoke.invoke(nil)
+      }.to output(/Revoked 3 tokens/).to_stdout
+    end
+
+    it 'prints error and calls exit on service error' do
+      allow(Kernel).to receive(:exit)
+      allow_any_instance_of(Verbena::TokenService).to receive(:revoke_expired).and_raise('boom')
+
+      expect {
+        task_revoke.invoke(nil)
+      }.to output(/ERROR: revoke_expired failed/).to_stderr
+
+      expect(Kernel).to have_received(:exit).with(1)
+    end
+  end
+end

--- a/spec/tasks/verbena/tokens_rake_spec.rb
+++ b/spec/tasks/verbena/tokens_rake_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe 'verbena:tokens tasks' do
 
   describe 'revoke_expired' do
     it 'prints dry run summary when dry flag is truthy' do
-      allow_any_instance_of(Verbena::TokenService).to receive(:expired_count).and_return(7)
+      service_double = instance_double(Verbena::TokenService, expired_count: 7)
+      allow(Verbena::TokenService).to receive(:new).and_return(service_double)
 
       expect {
         task_revoke.invoke('1')
@@ -24,7 +25,8 @@ RSpec.describe 'verbena:tokens tasks' do
     end
 
     it 'prints revoked count on success' do
-      allow_any_instance_of(Verbena::TokenService).to receive(:revoke_expired!).and_return(3)
+      service_double = instance_double(Verbena::TokenService, revoke_expired!: 3)
+      allow(Verbena::TokenService).to receive(:new).and_return(service_double)
 
       expect {
         task_revoke.invoke(nil)
@@ -33,7 +35,9 @@ RSpec.describe 'verbena:tokens tasks' do
 
     it 'prints error and calls exit on service error' do
       allow(Kernel).to receive(:exit)
-      allow_any_instance_of(Verbena::TokenService).to receive(:revoke_expired).and_raise('boom')
+      service_double = instance_double(Verbena::TokenService)
+      allow(service_double).to receive(:revoke_expired!).and_raise('boom')
+      allow(Verbena::TokenService).to receive(:new).and_return(service_double)
 
       expect {
         task_revoke.invoke(nil)


### PR DESCRIPTION
#12 の課題のうちの #38 の対応です。

This pull request refactors and improves the expired token revocation logic in the `Verbena::TokenService` and its associated Rake task. The changes introduce clearer, more explicit APIs for dry-run and destructive operations, centralize query logic to avoid divergence, and enhance error handling and test coverage for the Rake task.

**Service API improvements:**

* Added `expired_count` and `revoke_expired!` methods to `TokenService` for clearer, explicit dry-run and destructive APIs, delegating to the internal implementation.
* Centralized the expired token selection logic into the new `expired_relation` private method to ensure consistency across all expired token operations.

**Rake task improvements:**

* Refactored the `verbena:tokens:revoke_expired` Rake task to use the new service methods, improved argument parsing, and added robust error handling with clear error messages and process exit on failure.

**Test updates:**

* Updated `TokenService` specs to use the new `expired_count` and `revoke_expired!` methods, ensuring correct behavior for both dry-run and destructive operations. [[1]](diffhunk://#diff-6bd244921b84f2e9c631abd218a06f091ded1a582d7b88e4f15efe2a1b369067L13-R21) [[2]](diffhunk://#diff-6bd244921b84f2e9c631abd218a06f091ded1a582d7b88e4f15efe2a1b369067L32-R35) [[3]](diffhunk://#diff-6bd244921b84f2e9c631abd218a06f091ded1a582d7b88e4f15efe2a1b369067L57-R57)
* Added new specs for the Rake task, verifying output for dry-run, successful revocation, and error scenarios, including process exit on failure.