### PR TITLE
タスク claim.rake の改良

### DIFF
--- a/app/services/verbena/mail_queues_service.rb
+++ b/app/services/verbena/mail_queues_service.rb
@@ -94,6 +94,20 @@ module Verbena
     # @param older_than_hours [Float] この時間より前に claim されたレコードを対象とする（時間単位）
     # @param dry_run [Boolean] true の場合、実際には解放せず、対象レコード数のみ返す
     # @return [Integer] 解放されたレコード数（dry_run の場合は対象レコード数）
+    # Public thin wrappers to avoid callers accidentally passing `dry_run` incorrectly.
+    # - `count_stale_claims` returns the count of candidates without performing updates.
+    # - `release_stale_claims!` performs the release and returns the number of updated rows.
+    def count_stale_claims(older_than_hours: nil)
+      release_stale_claims(older_than_hours: older_than_hours, dry_run: true)
+    end
+
+    def release_stale_claims!(older_than_hours: nil)
+      release_stale_claims(older_than_hours: older_than_hours, dry_run: false)
+    end
+
+    private
+
+    # Core implementation — kept private to force callers to use thin, explicit wrappers above.
     def release_stale_claims(older_than_hours: 1.0, dry_run: false)
       hours = self.class.normalize_hours_arg(older_than_hours)
       raise NegativeClaimHoursError, 'older_than_hours must be >= 0' if hours.negative?
@@ -123,6 +137,8 @@ module Verbena
         count
       end
     end
+
+    public
 
     # 現在 claim されているが配送結果がないレコードの情報を取得する
     #

--- a/app/services/verbena/mail_queues_service.rb
+++ b/app/services/verbena/mail_queues_service.rb
@@ -95,50 +95,33 @@ module Verbena
     # @param dry_run [Boolean] true の場合、実際には解放せず、対象レコード数のみ返す
     # @return [Integer] 解放されたレコード数（dry_run の場合は対象レコード数）
     # Public thin wrappers to avoid callers accidentally passing `dry_run` incorrectly.
-    # - `count_stale_claims` returns the count of candidates without performing updates.
-    # - `release_stale_claims!` performs the release and returns the number of updated rows.
-    def count_stale_claims(older_than_hours: nil)
+    #
+    # count_stale_claims(older_than_hours: 1.0) -> Integer
+    #  - Purpose: Return the number of stale claimed MailQueue records that would be
+    #    released if executed. This is a safe, read-only operation used for dry-run
+    #    checks and reporting.
+    #  - Parameters:
+    #    - older_than_hours [Float] Threshold in hours; records claimed at or before
+    #      `Time.current - older_than_hours.hours` are considered stale. Defaults to 1.0.
+    #  - Returns: Integer count of matching records.
+    #  - Exceptions: May raise ArgumentError if `older_than_hours` cannot be coerced to Float,
+    #    or NegativeClaimHoursError if a negative number is provided.
+    def count_stale_claims(older_than_hours: 1.0)
       release_stale_claims(older_than_hours: older_than_hours, dry_run: true)
     end
 
-    def release_stale_claims!(older_than_hours: nil)
+    # release_stale_claims!(older_than_hours: 1.0) -> Integer
+    #  - Purpose: Mutating operation that releases (clears `session_id` and `claimed_at`)
+    #    stale claimed MailQueue records. Use with care; this performs an UPDATE.
+    #  - Parameters:
+    #    - older_than_hours [Float] Threshold in hours; records claimed at or before
+    #      `Time.current - older_than_hours.hours` are released. Defaults to 1.0.
+    #  - Returns: Integer number of rows updated (released).
+    #  - Exceptions: May raise ArgumentError for invalid numeric input, or
+    #    NegativeClaimHoursError if a negative number is provided.
+    def release_stale_claims!(older_than_hours: 1.0)
       release_stale_claims(older_than_hours: older_than_hours, dry_run: false)
     end
-
-    private
-
-    # Core implementation — kept private to force callers to use thin, explicit wrappers above.
-    def release_stale_claims(older_than_hours: 1.0, dry_run: false)
-      hours = self.class.normalize_hours_arg(older_than_hours)
-      raise NegativeClaimHoursError, 'older_than_hours must be >= 0' if hours.negative?
-      older_than = hours.hours.ago
-
-      relation = MailQueue.stale_claims_relation(older_than: older_than)
-
-      if dry_run
-        count = relation.count
-        logger.info(structured_log(
-          event: 'mail_queues.dry_run',
-          level: 'info',
-          session_id: nil,
-          mail_queue_id: nil,
-          message: "DRY RUN: #{count} stale claims would be released (older than #{hours} hours as of #{older_than})"
-        ))
-        count
-      else
-        count = relation.update_all(session_id: nil, claimed_at: nil, updated_at: Time.current)
-        logger.info(structured_log(
-          event: 'mail_queues.release',
-          level: 'info',
-          session_id: nil,
-          mail_queue_id: nil,
-          message: "Released #{count} stale claims older than #{hours} hours (as of #{older_than})"
-        ))
-        count
-      end
-    end
-
-    public
 
     # 現在 claim されているが配送結果がないレコードの情報を取得する
     #
@@ -175,6 +158,39 @@ module Verbena
       return 1.0 if val.nil?
       return 1.0 if val.is_a?(String) && val.strip.empty?
       Float(val)
+    end
+
+    private
+
+    # Core implementation — kept private to force callers to use thin, explicit wrappers above.
+    def release_stale_claims(older_than_hours: 1.0, dry_run: false)
+      hours = self.class.normalize_hours_arg(older_than_hours)
+      raise NegativeClaimHoursError, 'older_than_hours must be >= 0' if hours.negative?
+      older_than = hours.hours.ago
+
+      relation = MailQueue.stale_claims_relation(older_than: older_than)
+
+      if dry_run
+        count = relation.count
+        logger.info(structured_log(
+          event: 'mail_queues.dry_run',
+          level: 'info',
+          session_id: nil,
+          mail_queue_id: nil,
+          message: "DRY RUN: #{count} stale claims would be released (older than #{hours} hours as of #{older_than})"
+        ))
+        count
+      else
+        count = relation.update_all(session_id: nil, claimed_at: nil, updated_at: Time.current)
+        logger.info(structured_log(
+          event: 'mail_queues.release',
+          level: 'info',
+          session_id: nil,
+          mail_queue_id: nil,
+          message: "Released #{count} stale claims older than #{hours} hours (as of #{older_than})"
+        ))
+        count
+      end
     end
   end
 end

--- a/app/services/verbena/mail_queues_service.rb
+++ b/app/services/verbena/mail_queues_service.rb
@@ -79,51 +79,45 @@ module Verbena
       end
     end
 
+    # 指定された id の MailQueue レコードを削除します。
     #
+    # @param id [Integer] 削除する MailQueue の ID
+    # @return [MailQueue] 削除された MailQueue オブジェクト
+    # @raise [ActiveRecord::RecordNotFound] 指定された id のレコードが存在しない場合
     def destroy_mail_queue_by_id!(id)
       destroy_mail_queue!(MailQueue.find(id))
     end
 
+    # 指定された MailQueue レコードを削除します。
     #
+    # @param mail_queue [MailQueue] 削除する MailQueue オブジェクト
+    # @return [MailQueue] 削除された MailQueue オブジェクト
     def destroy_mail_queue!(mail_queue)
       mail_queue.destroy!
     end
 
-    # スタック（長時間 claim されているが配送されていない）mail_queues の claim を解放する
+    # 長時間 claim されているが配送されていない状態の MailQueue レコード数を返します。
     #
-    # @param older_than_hours [Float] この時間より前に claim されたレコードを対象とする（時間単位）
-    # @param dry_run [Boolean] true の場合、実際には解放せず、対象レコード数のみ返す
-    # @return [Integer] 解放されたレコード数（dry_run の場合は対象レコード数）
-    # Public thin wrappers to avoid callers accidentally passing `dry_run` incorrectly.
-    #
-    # count_stale_claims(older_than_hours: 1.0) -> Integer
-    #  - Purpose: Return the number of stale claimed MailQueue records that would be
-    #    released if executed. This is a safe, read-only operation used for dry-run
-    #    checks and reporting.
-    #  - Parameters:
-    #    - older_than_hours [Float] Threshold in hours; records claimed at or before
-    #      `Time.current - older_than_hours.hours` are considered stale. Defaults to 1.0.
-    #  - Returns: Integer count of matching records.
-    #  - Exceptions: May raise ArgumentError if `older_than_hours` cannot be coerced to Float,
-    #    or NegativeClaimHoursError if a negative number is provided.
+    # @param older_than_hours [Float] 時間単位の閾値（既定値: 1.0）
+    # @return [Integer] 対象レコード数
+    # @raise [ArgumentError] older_than_hours が Float に変換できない場合
+    # @raise [NegativeClaimHoursError] 負の数が指定された場合
     def count_stale_claims(older_than_hours: 1.0)
       release_stale_claims(older_than_hours: older_than_hours, dry_run: true)
     end
 
-    # release_stale_claims!(older_than_hours: 1.0) -> Integer
-    #  - Purpose: Mutating operation that releases (clears `session_id` and `claimed_at`)
-    #    stale claimed MailQueue records. Use with care; this performs an UPDATE.
-    #  - Parameters:
-    #    - older_than_hours [Float] Threshold in hours; records claimed at or before
-    #      `Time.current - older_than_hours.hours` are released. Defaults to 1.0.
-    #  - Returns: Integer number of rows updated (released).
-    #  - Exceptions: May raise ArgumentError for invalid numeric input, or
-    #    NegativeClaimHoursError if a negative number is provided.
+    # 長時間 claim されているが配送されていない状態の MailQueue レコードを解放します。
+    # session_id と claimed_at をクリアします。
+    #
+    # @param older_than_hours [Float] 時間単位の閾値（既定値: 1.0）
+    # @return [Integer] 更新された行数
+    # @raise [ArgumentError] older_than_hours が Float に変換できない場合
+    # @raise [NegativeClaimHoursError] 負の数が指定された場合
     def release_stale_claims!(older_than_hours: 1.0)
       release_stale_claims(older_than_hours: older_than_hours, dry_run: false)
     end
 
-    # 現在 claim されているが配送結果がないレコードの情報を取得する
+    # 現在 claim されているが配送結果がないレコードの情報を取得します。
     #
     # @return [Array<Hash>] スタックレコードの情報配列
     # @raise [NegativeAgeError] claimed_at が未来の場合（age_secondsが負の場合）
@@ -150,10 +144,9 @@ module Verbena
       end
     end
 
-    # Normalize an "hours" argument.
-    # - nil or blank string => uses default 1.0 hour
-    # - numeric or numeric string (including "0" / 0) => converted via Float(...)
-    # Note: Negative values are allowed here and validated by business logic in `release_stale_claims`.
+    # 「時間」引数を正規化します。
+    # - nil または空白文字列 => 既定値 1.0 時間を使用
+    # - 数値または数値文字列（"0" / 0 を含む） => Float(...) で変換
     def self.normalize_hours_arg(val)
       return 1.0 if val.nil?
       return 1.0 if val.is_a?(String) && val.strip.empty?
@@ -162,7 +155,22 @@ module Verbena
 
     private
 
-    # Core implementation — kept private to force callers to use thin, explicit wrappers above.
+    # 長時間 claim されているが配送されていない mail_queues の claim を解放するコア実装
+    #
+    # このメソッドは公開ラッパーメソッドから使用され、
+    # 呼び出し側が明示的な意図を示すエントリーポイントを使用するよう private としています。
+    #
+    # @param older_than_hours [Numeric, String, nil]
+    #   時間単位の閾値。この値は {.normalize_hours_arg} で正規化され、
+    #   nil/空白（1.0として扱う）、数値、または数値文字列を受け付けます。正規化後の値は
+    #   非負である必要があり、そうでない場合は {NegativeClaimHoursError} が発生します。
+    # @param dry_run [Boolean]
+    #   true の場合、データベースの更新は行われず、対象レコード数のみをカウントし、
+    #   解放されるはずだったログを記録します。false の場合、対象レコードを更新して
+    #   claim フィールド（session_id, claimed_at）をクリアします。
+    #
+    # @return [Integer] 解放された（またはドライランモードで解放されるはずの）スタック claim の数
+    # @raise [NegativeClaimHoursError] 正規化された older_than_hours が負の場合
     def release_stale_claims(older_than_hours: 1.0, dry_run: false)
       hours = self.class.normalize_hours_arg(older_than_hours)
       raise NegativeClaimHoursError, 'older_than_hours must be >= 0' if hours.negative?

--- a/docs/CLAIM_HARDENING.ja.md
+++ b/docs/CLAIM_HARDENING.ja.md
@@ -151,10 +151,10 @@ relation = MailQueue.stale_claims_relation(older_than: 1.hour.ago)
 
 # サービス経由で解放（更新件数を返す）
 service = Verbena::MailQueuesService.new
-changed = service.release_stale_claims # 既定は 1.0 時間
+changed = service.release_stale_claims! # 既定は 1.0 時間
 
 # 閾値（時間・hours）とドライラン
-dry_count = service.release_stale_claims(older_than_hours: 2.0, dry_run: true)
+dry_count = service.count_stale_claims(older_than_hours: 2.0)
 
 # 備考:
 # - しきい値は「以下」を含む（claimed_at <= older_than）

--- a/docs/CLAIM_HARDENING.md
+++ b/docs/CLAIM_HARDENING.md
@@ -152,10 +152,10 @@ relation = MailQueue.stale_claims_relation(older_than: 1.hour.ago)
 
 # Release via service (returns updated row count)
 service = Verbena::MailQueuesService.new
-changed = service.release_stale_claims # default: 1.0 hour
+changed = service.release_stale_claims! # default: 1.0 hour
 
 # Custom threshold (hours) and dry run
-dry_count = service.release_stale_claims(older_than_hours: 2.0, dry_run: true)
+dry_count = service.count_stale_claims(older_than_hours: 2.0)
 
 # Notes:
 # - Boundary is inclusive: claimed_at <= older_than

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -145,10 +145,10 @@ VERBENA_IN_BATCHES_OF=1000
 ```ruby
 # 24時間以上 claimed 状態のレコードを解放
 service = Verbena::MailQueuesService.new
-service.release_stale_claims(older_than_hours: 24.0)
+service.release_stale_claims!(older_than_hours: 24.0)
 
 # ドライラン（件数のみ確認）
-service.release_stale_claims(older_than_hours: 24.0, dry_run: true)
+service.count_stale_claims(older_than_hours: 24.0)
 ```
 
 Rakeタスクも用意されています：

--- a/lib/tasks/verbena/claim.rake
+++ b/lib/tasks/verbena/claim.rake
@@ -7,7 +7,11 @@ namespace :verbena do
         dry_run = Verbena::ServiceBase.truthy?(args[:dry])
 
         service = Verbena::MailQueuesService.new
-        stale_count = service.release_stale_claims(older_than_hours: older_than_hours, dry_run: dry_run)
+        if dry_run
+          stale_count = service.count_stale_claims(older_than_hours: older_than_hours)
+        else
+          stale_count = service.release_stale_claims!(older_than_hours: older_than_hours)
+        end
 
         hour_unit = 'hour'.pluralize(older_than_hours.round)
         if dry_run

--- a/spec/models/mail_queue_claim_hardening_spec.rb
+++ b/spec/models/mail_queue_claim_hardening_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe MailQueue, type: :model do
     end
 
     it '既定（1時間より古い）で2件が解放される' do
-      changed = Verbena::MailQueuesService.new.release_stale_claims
+      changed = Verbena::MailQueuesService.new.release_stale_claims!
       expect(changed).to eq 2
 
       expect(@stale_90m.reload.session_id).to be_nil
@@ -82,7 +82,7 @@ RSpec.describe MailQueue, type: :model do
     end
 
     it '閾値（30分前）を指定すると2件が解放される' do
-      changed = Verbena::MailQueuesService.new.release_stale_claims(older_than_hours: 0.5)
+      changed = Verbena::MailQueuesService.new.release_stale_claims!(older_than_hours: 0.5)
       expect(changed).to eq 2
     end
   end
@@ -122,7 +122,7 @@ RSpec.describe MailQueue, type: :model do
     end
 
     it 'デフォルト（1時間前）: 120/90/60 が解放される（合計3件）' do
-      changed = Verbena::MailQueuesService.new.release_stale_claims
+      changed = Verbena::MailQueuesService.new.release_stale_claims!
       expect(changed).to eq 3
 
       [@r120, @r90, @r60].each { |r| expect(r.reload.session_id).to be_nil }
@@ -131,7 +131,7 @@ RSpec.describe MailQueue, type: :model do
     end
 
     it '30分前: 120/90/60/31/30 が解放される（合計5件）' do
-      changed = Verbena::MailQueuesService.new.release_stale_claims(older_than_hours: 0.5)
+      changed = Verbena::MailQueuesService.new.release_stale_claims!(older_than_hours: 0.5)
       expect(changed).to eq 5
 
       [@r120, @r90, @r60, @r31, @r30].each { |r| expect(r.reload.session_id).to be_nil }
@@ -139,13 +139,13 @@ RSpec.describe MailQueue, type: :model do
     end
 
     it '30分の境界: ちょうど30分は解放、29分は解放されない' do
-      Verbena::MailQueuesService.new.release_stale_claims(older_than_hours: 0.5)
+      Verbena::MailQueuesService.new.release_stale_claims!(older_than_hours: 0.5)
       expect(@r30.reload.session_id).to be_nil
       expect(@r29.reload.session_id).not_to be_nil
     end
 
     it '100分前: 120分のみ解放（合計1件）' do
-      changed = Verbena::MailQueuesService.new.release_stale_claims(older_than_hours: (100.0/60.0))
+      changed = Verbena::MailQueuesService.new.release_stale_claims!(older_than_hours: (100.0/60.0))
       expect(changed).to eq 1
       expect(@r120.reload.session_id).to be_nil
       [@r90, @r60, @r31, @r30, @r29, @r20].each { |r| expect(r.reload.session_id).not_to be_nil }

--- a/spec/models/mail_queue_spec.rb
+++ b/spec/models/mail_queue_spec.rb
@@ -279,7 +279,7 @@ RSpec.describe MailQueue, type: :model do
         it '1時間より古い claim が解放される' do
           service = Verbena::MailQueuesService.new
           expect {
-            service.release_stale_claims
+            service.release_stale_claims!
           }.to change { described_class.where(session_id: nil).count }.by(2)
 
           @stale_row1.reload
@@ -298,7 +298,7 @@ RSpec.describe MailQueue, type: :model do
 
         it '解放されたレコード数を返す' do
           service = Verbena::MailQueuesService.new
-          result = service.release_stale_claims
+          result = service.release_stale_claims!
           expect(result).to eq(2)
         end
 
@@ -307,7 +307,7 @@ RSpec.describe MailQueue, type: :model do
           FactoryBot.create(:delivery_response, mail_queue: delivered)
 
           service = Verbena::MailQueuesService.new
-          result = service.release_stale_claims
+          result = service.release_stale_claims!
 
           expect(result).to eq(2)
           expect(delivered.reload.session_id).to eq('delivered')
@@ -319,7 +319,7 @@ RSpec.describe MailQueue, type: :model do
         it '30分より古い claim が解放される' do
           service = Verbena::MailQueuesService.new
           expect {
-            service.release_stale_claims(older_than_hours: 0.5)
+            service.release_stale_claims!(older_than_hours: 0.5)
           }.to change { described_class.where(session_id: nil).count }.by(3)
         end
       end

--- a/spec/services/verbena/mail_queues_service_spec.rb
+++ b/spec/services/verbena/mail_queues_service_spec.rb
@@ -380,10 +380,10 @@ RSpec.describe Verbena::MailQueuesService, type: :service do
         include_context 'with_claimed_and_delivered_records'
 
         it 'dry_runの件数と実行の更新件数が等しい' do
-          dry = instance.release_stale_claims(dry_run: true)
+          dry = instance.count_stale_claims
           expect(dry).to eq 2
 
-          changed = instance.release_stale_claims(dry_run: false)
+          changed = instance.release_stale_claims!
           expect(changed).to eq dry
 
           expect(MailQueue.find(@stale1.id).session_id).to be_nil
@@ -397,11 +397,11 @@ RSpec.describe Verbena::MailQueuesService, type: :service do
         include_context 'with_claimed_and_delivered_records'
 
         it 'dry_runの件数と実行の更新件数が等しい（30分ちょうども含む）' do
-          dry = instance.release_stale_claims(older_than_hours: 0.5, dry_run: true)
+          dry = instance.count_stale_claims(older_than_hours: 0.5)
           # 30分「以前（含む）」は stale1, stale2, fresh(ちょうど30分) の3件
           expect(dry).to eq 3
 
-          changed = instance.release_stale_claims(older_than_hours: 0.5, dry_run: false)
+          changed = instance.release_stale_claims!(older_than_hours: 0.5)
           expect(changed).to eq dry
         end
       end
@@ -410,16 +410,16 @@ RSpec.describe Verbena::MailQueuesService, type: :service do
         include_context 'with_claimed_and_delivered_records'
 
         it '数値に変換可能な文字列を受け付ける' do
-          expect(instance.release_stale_claims(older_than_hours: '0.5', dry_run: true)).to eq 3
+          expect(instance.count_stale_claims(older_than_hours: '0.5')).to eq 3
         end
 
         it 'nil はデフォルトの 1.0 として扱う' do
-          expect(instance.release_stale_claims(older_than_hours: nil, dry_run: true)).to eq 2
+          expect(instance.count_stale_claims(older_than_hours: nil)).to eq 2
         end
 
         it '負の値は NegativeClaimHoursError を送出する' do
           expect {
-            instance.release_stale_claims(older_than_hours: -1, dry_run: true)
+            instance.count_stale_claims(older_than_hours: -1)
           }.to raise_error(Verbena::MailQueuesService::NegativeClaimHoursError, 'older_than_hours must be >= 0')
         end
 
@@ -429,7 +429,7 @@ RSpec.describe Verbena::MailQueuesService, type: :service do
 
         it '非数値文字列は ArgumentError を送出する (Float による例外が伝播する)' do
           expect {
-            instance.release_stale_claims(older_than_hours: 'abc', dry_run: true)
+            instance.count_stale_claims(older_than_hours: 'abc')
           }.to raise_error(ArgumentError)
         end
       end

--- a/spec/services/verbena/mail_queues_service_spec.rb
+++ b/spec/services/verbena/mail_queues_service_spec.rb
@@ -423,6 +423,12 @@ RSpec.describe Verbena::MailQueuesService, type: :service do
           }.to raise_error(Verbena::MailQueuesService::NegativeClaimHoursError, 'older_than_hours must be >= 0')
         end
 
+        it 'release_stale_claims! も負の値で NegativeClaimHoursError を送出する' do
+          expect {
+            instance.release_stale_claims!(older_than_hours: -1)
+          }.to raise_error(Verbena::MailQueuesService::NegativeClaimHoursError, 'older_than_hours must be >= 0')
+        end
+
         it 'normalize_hours_arg は型変換のみ行い、負値もそのまま返す（負値検証は release_stale_claims 側）' do
           expect(described_class.normalize_hours_arg(-1)).to eq(-1.0)
         end
@@ -430,6 +436,12 @@ RSpec.describe Verbena::MailQueuesService, type: :service do
         it '非数値文字列は ArgumentError を送出する (Float による例外が伝播する)' do
           expect {
             instance.count_stale_claims(older_than_hours: 'abc')
+          }.to raise_error(ArgumentError)
+        end
+
+        it 'release_stale_claims! も非数値文字列で ArgumentError を送出する' do
+          expect {
+            instance.release_stale_claims!(older_than_hours: 'abc')
           }.to raise_error(ArgumentError)
         end
       end

--- a/spec/tasks/verbena/claim_rake_spec.rb
+++ b/spec/tasks/verbena/claim_rake_spec.rb
@@ -48,29 +48,29 @@ RSpec.describe 'verbena:claim tasks' do
     end
 
     it 'runs dry-run mode and prints summary' do
-      service = instance_double(Verbena::MailQueuesService, release_stale_claims: 3)
+      service = instance_double(Verbena::MailQueuesService, count_stale_claims: 3)
       allow(Verbena::MailQueuesService).to receive(:new).and_return(service)
 
       expect {
         task_release_stale.invoke('2', 'true')
       }.to output(/DRY RUN: Would release 3 stale claims older than 2.0 hours/).to_stdout
-      expect(service).to have_received(:release_stale_claims).with(older_than_hours: 2.0, dry_run: true)
+      expect(service).to have_received(:count_stale_claims).with(older_than_hours: 2.0)
     end
 
     it 'runs non-dry mode and prints summary' do
-      service = instance_double(Verbena::MailQueuesService, release_stale_claims: 5)
+      service = instance_double(Verbena::MailQueuesService, release_stale_claims!: 5)
       allow(Verbena::MailQueuesService).to receive(:new).and_return(service)
 
       expect {
         task_release_stale.invoke('1.5', nil)
       }.to output(/Released 5 stale claims older than 1.5 hours/).to_stdout
-      expect(service).to have_received(:release_stale_claims).with(older_than_hours: 1.5, dry_run: false)
+      expect(service).to have_received(:release_stale_claims!).with(older_than_hours: 1.5)
     end
 
     it 'prints error and exits when service raises' do
       service = instance_double(Verbena::MailQueuesService)
       allow(Verbena::MailQueuesService).to receive(:new).and_return(service)
-      allow(service).to receive(:release_stale_claims).and_raise(StandardError, 'boom')
+      allow(service).to receive(:release_stale_claims!).and_raise(StandardError, 'boom')
 
       stderr_output = StringIO.new
       expect {


### PR DESCRIPTION
サービスを呼び出す際に dry run フラグを誤るとダメージが大きいため、フラグで渡すのではなく、別のメソッドを呼ぶように改良します。

This pull request refactors the API for releasing stale mail queue claims in `Verbena::MailQueuesService` by introducing explicit, purpose-specific public methods. The main goal is to prevent accidental misuse of the `dry_run` parameter, making the codebase safer and easier to understand. The change is accompanied by updates to documentation, rake tasks, and tests to use the new methods.

**API Improvements and Refactoring:**

* Added two new explicit public methods: `count_stale_claims` (for dry-run/counting only) and `release_stale_claims!` (for actually releasing claims), and made the core implementation private to enforce correct usage.
* Updated internal method visibility and documentation to clarify intended usage.

**Documentation Updates:**

* Updated all relevant documentation (`CLAIM_HARDENING.md`, `CLAIM_HARDENING.ja.md`, `FAQ.md`) to use the new method names and signatures, removing references to the old `dry_run` parameter. (Fdfc33b8L152R152, Fd7818d1L151R151, [docs/FAQ.mdL148-R151](diffhunk://#diff-0bb42a85d04c8b7c9b659307979fd43e8f6e084283a300bfff959adfcbddfd17L148-R151))

**Rake Task and Test Adjustments:**

* Modified the `verbena:release_stale_claims` rake task to use the new methods, ensuring correct behavior in both dry-run and actual release modes.
* Refactored all related specs and test doubles to use `count_stale_claims` and `release_stale_claims!`, removing direct usage of the old parameterized method. [[1]](diffhunk://#diff-72ee600aa2c1b42679aea1d1a373dadaa097e81647da3848be1f5daa35e83761L75-R75) [[2]](diffhunk://#diff-72ee600aa2c1b42679aea1d1a373dadaa097e81647da3848be1f5daa35e83761L85-R85) [[3]](diffhunk://#diff-72ee600aa2c1b42679aea1d1a373dadaa097e81647da3848be1f5daa35e83761L125-R125) [[4]](diffhunk://#diff-72ee600aa2c1b42679aea1d1a373dadaa097e81647da3848be1f5daa35e83761L134-R148) [[5]](diffhunk://#diff-d3e1c0517c1c6b560b644bb40651b7b4e0dca817b488bcb248e768e76bab58d3L282-R282) [[6]](diffhunk://#diff-d3e1c0517c1c6b560b644bb40651b7b4e0dca817b488bcb248e768e76bab58d3L301-R301) [[7]](diffhunk://#diff-d3e1c0517c1c6b560b644bb40651b7b4e0dca817b488bcb248e768e76bab58d3L310-R310) [[8]](diffhunk://#diff-d3e1c0517c1c6b560b644bb40651b7b4e0dca817b488bcb248e768e76bab58d3L322-R322) [[9]](diffhunk://#diff-45a908a6ed20522e30b1657579038b860eaf34e46c1dcfa06cb6023441464089L383-R386) [[10]](diffhunk://#diff-45a908a6ed20522e30b1657579038b860eaf34e46c1dcfa06cb6023441464089L400-R404) [[11]](diffhunk://#diff-45a908a6ed20522e30b1657579038b860eaf34e46c1dcfa06cb6023441464089L413-R422) [[12]](diffhunk://#diff-45a908a6ed20522e30b1657579038b860eaf34e46c1dcfa06cb6023441464089L432-R432) [[13]](diffhunk://#diff-ca65161c3f5945f381780a9f77b4a60b649751ca6ac4e37d80e37c250976c139L51-R73)

These changes help ensure that claim release operations are performed intentionally and safely, reducing the risk of accidental data modifications.