### PR TITLE
インデックス追加 (mail_queues と delivery_responses)

### DIFF
--- a/db/migrate/20260108090000_add_indexes_for_performance.rb
+++ b/db/migrate/20260108090000_add_indexes_for_performance.rb
@@ -1,0 +1,13 @@
+class AddIndexesForPerformance < ActiveRecord::Migration[7.1]
+  def change
+    # For deadline queries on mail_queues (e.g., WHERE timer_at <= NOW())
+    unless index_exists?(:mail_queues, :timer_at)
+      add_index :mail_queues, :timer_at
+    end
+
+    # For fetching the latest delivery response per mail_queue efficiently
+    unless index_exists?(:delivery_responses, [:mail_queue_id, :responded_at])
+      add_index :delivery_responses, [:mail_queue_id, :responded_at]
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_09_02_120000) do
+ActiveRecord::Schema[7.1].define(version: 2026_01_08_090000) do
   create_table "delivery_responses", charset: "utf8mb4", force: :cascade do |t|
     t.bigint "mail_queue_id", null: false
     t.datetime "responded_at"
@@ -19,6 +19,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_09_02_120000) do
     t.string "message_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["mail_queue_id", "responded_at"], name: "index_delivery_responses_on_mail_queue_id_and_responded_at"
     t.index ["mail_queue_id"], name: "index_delivery_responses_on_mail_queue_id"
   end
 
@@ -42,6 +43,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_09_02_120000) do
     t.index ["session_id", "claimed_at"], name: "index_mail_queues_on_session_id_and_claimed_at"
     t.index ["session_id"], name: "index_mail_queues_on_session_id"
     t.index ["timer_at", "session_id"], name: "index_mail_queues_on_timer_at_and_session_id"
+    t.index ["timer_at"], name: "index_mail_queues_on_timer_at"
   end
 
   create_table "tokens", charset: "utf8mb4", force: :cascade do |t|


### PR DESCRIPTION
#5 の対応です。
まだ運用前で計測できていませんが、 GPT に相談してとりあえずこれ、というものを追加しておきます。

---

### 計画と実施内容

- 現在のインデックスを評価：MySQL の設定と現在のスキーマを確認しました。
- 最小限で効果の高いインデックスを実装：代表的なクエリに沿った 2 つのインデックスを追加しました。
- 任意の検証手順を提示：マイグレーションの実行方法と EXPLAIN の確認方法。

### 調査結果

- DB：database.yml より MySQL（mysql2）
- schema.rb にある既存インデックス：
  - mail_queues：session_id、claimed_at、(session_id, claimed_at)、(timer_at, session_id)、eml_source_id
  - delivery_responses：mail_queue_id
- 不足点：
  - mail_queues.timer_at の単独インデックスがない
  - delivery_responses(mail_queue_id, responded_at) の複合インデックスがない

### 追加した内容

- 新しいマイグレーション：20260108090000_add_indexes_for_performance.rb
- mail_queues：
  - `session_id` で絞り込まない期限系クエリをサポートするため、`timer_at` にインデックスを追加
- delivery_responses：
  - 「キューごとの最新レスポンス」取得を高速化するため、`(mail_queue_id, responded_at)` の複合インデックスを追加

### 理由

- `WHERE timer_at <= NOW()` は `mail_queues(timer_at)` を利用可能
- `SELECT … FROM delivery_responses WHERE mail_queue_id = ? ORDER BY responded_at DESC LIMIT 1` は `(mail_queue_id, responded_at)` を利用可能

### なぜ今 `(session_id, id)` を追加しないのか

`session_id` で取得して `id` でソートするケースが頻繁にあるなら有用ですが、具体的な使用実績がない現時点ではインデックス肥大化のリスクがあります。すでに `session_id` 単体および `(timer_at, session_id)` があるため、初手は最小限に留めました。

---

