### PR TITLE
CI - rspec を実行するワークフローの追加

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -58,6 +58,54 @@ jobs:
       - name: Run RSpec
         run: bundle exec rspec
 
+  # MySQL-only schema verification job:
+  # Builds the schema from migrations and compares the dumped `db/schema.rb`
+  # with the committed file to ensure the MySQL-centric `db/schema.rb`
+  # is kept in sync with migrations.
+  schema-verify-mysql:
+    name: schema verify (mysql)
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mariadb:10.6.10
+        env:
+          MYSQL_ROOT_PASSWORD: password
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -uroot -ppassword"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+
+      - name: Install system packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            default-libmysqlclient-dev
+
+      - name: Save committed schema
+        run: |
+          if [ -f db/schema.rb ]; then git show HEAD:db/schema.rb > db/schema_committed.rb || true; else touch db/schema_committed.rb; fi
+
+      - name: Build schema from migrations
+        run: |
+          bin/rails db:create
+          bin/rails db:migrate
+          bin/rails db:schema:dump
+
+      - name: Compare schema files
+        run: |
+          git --no-pager diff --no-index --exit-code db/schema_committed.rb db/schema.rb
+
   rspec-postgresql:
     name: rspec (postgresql)
     runs-on: ubuntu-latest

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -1,0 +1,152 @@
+# NOTE: This project’s db/schema.rb is MySQL-centric.
+# To keep CI reliable across mysql/postgresql/sqlite,
+# we avoid db:schema:load and always build the test DB via migrations.
+
+name: RSpec (manual)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  rspec-mysql:
+    name: rspec (mysql)
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        # Use MariaDB for CI (compatible with MySQL in this project)
+        image: mariadb:10.6.10
+        env:
+          MYSQL_ROOT_PASSWORD: password
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -uroot -ppassword"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=20
+
+    env:
+      RAILS_ENV: test
+      DATABASE_NAME: verbena
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+
+      - name: Install system packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            default-libmysqlclient-dev \
+            libpq-dev \
+            libsqlite3-dev
+
+      - name: Configure DB env (mysql)
+        run: |
+          echo "DATABASE_ADAPTER=mysql2" >> $GITHUB_ENV
+          echo "DATABASE_HOST=127.0.0.1" >> $GITHUB_ENV
+          echo "DATABASE_PORT=3306" >> $GITHUB_ENV
+          echo "VERBENA_DATABASE_USER=root" >> $GITHUB_ENV
+          echo "VERBENA_DATABASE_PASSWORD=password" >> $GITHUB_ENV
+
+      - name: Prepare database
+        run: |
+          bin/rails db:prepare
+
+      - name: Run RSpec
+        run: bundle exec rspec
+
+  rspec-postgresql:
+    name: rspec (postgresql)
+    runs-on: ubuntu-latest
+    services:
+      postgresql:
+        image: postgres:15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd="pg_isready -U postgres"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=20
+
+    env:
+      RAILS_ENV: test
+      DATABASE_NAME: verbena
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+
+      - name: Install system packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            default-libmysqlclient-dev \
+            libpq-dev \
+            libsqlite3-dev
+
+      - name: Configure DB env (postgresql)
+        run: |
+          echo "DATABASE_ADAPTER=postgresql" >> $GITHUB_ENV
+          echo "DATABASE_HOST=127.0.0.1" >> $GITHUB_ENV
+          echo "DATABASE_PORT=5432" >> $GITHUB_ENV
+          echo "VERBENA_DATABASE_USER=postgres" >> $GITHUB_ENV
+          echo "VERBENA_DATABASE_PASSWORD=postgres" >> $GITHUB_ENV
+
+      - name: Prepare database
+        run: |
+          bin/rails db:create
+          bin/rails db:migrate
+
+      - name: Run RSpec
+        run: bundle exec rspec
+
+  rspec-sqlite:
+    name: rspec (sqlite)
+    runs-on: ubuntu-latest
+
+    env:
+      RAILS_ENV: test
+      DATABASE_NAME: verbena
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+
+      - name: Install system packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            default-libmysqlclient-dev \
+            libpq-dev \
+            libsqlite3-dev
+
+      - name: Configure DB env (sqlite)
+        run: |
+          echo "DATABASE_ADAPTER=sqlite3" >> $GITHUB_ENV
+
+      - name: Prepare database
+        run: |
+          bin/rails db:create
+          bin/rails db:migrate
+
+      - name: Run RSpec
+        run: bundle exec rspec

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -52,7 +52,8 @@ jobs:
 
       - name: Prepare database
         run: |
-          bin/rails db:prepare
+          bin/rails db:create
+          bin/rails db:migrate
 
       - name: Run RSpec
         run: bundle exec rspec

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -40,10 +40,7 @@ jobs:
       - name: Install system packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            default-libmysqlclient-dev \
-            libpq-dev \
-            libsqlite3-dev
+          sudo apt-get install -y --no-install-recommends default-libmysqlclient-dev
 
       - name: Configure DB env (mysql)
         run: |
@@ -93,9 +90,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            default-libmysqlclient-dev \
-            libpq-dev \
-            libsqlite3-dev
+            libpq-dev
 
       - name: Configure DB env (postgresql)
         run: |
@@ -134,10 +129,7 @@ jobs:
       - name: Install system packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            default-libmysqlclient-dev \
-            libpq-dev \
-            libsqlite3-dev
+          sudo apt-get install -y --no-install-recommends libsqlite3-dev
 
       - name: Configure DB env (sqlite)
         run: |

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -31,16 +31,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Install system packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends default-libmysqlclient-dev libpq-dev libsqlite3-dev
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.2'
           bundler-cache: true
-
-      - name: Install system packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends default-libmysqlclient-dev
 
       - name: Configure DB env (mysql)
         run: |
@@ -84,17 +84,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Install system packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends default-libmysqlclient-dev libpq-dev libsqlite3-dev
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.2'
           bundler-cache: true
-
-      - name: Install system packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            default-libmysqlclient-dev
 
       - name: Configure DB env (mysql)
         run: |
@@ -141,17 +140,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Install system packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends default-libmysqlclient-dev libpq-dev libsqlite3-dev
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.2'
           bundler-cache: true
-
-      - name: Install system packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            libpq-dev
 
       - name: Configure DB env (postgresql)
         run: |
@@ -181,16 +179,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Install system packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends default-libmysqlclient-dev libpq-dev libsqlite3-dev
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.2'
           bundler-cache: true
-
-      - name: Install system packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends libsqlite3-dev
 
       - name: Configure DB env (sqlite)
         run: |

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -76,6 +76,10 @@ jobs:
           --health-timeout=5s
           --health-retries=20
 
+    env:
+      RAILS_ENV: test
+      DATABASE_NAME: verbena
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -91,6 +95,14 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             default-libmysqlclient-dev
+
+      - name: Configure DB env (mysql)
+        run: |
+          echo "DATABASE_ADAPTER=mysql2" >> $GITHUB_ENV
+          echo "DATABASE_HOST=127.0.0.1" >> $GITHUB_ENV
+          echo "DATABASE_PORT=3306" >> $GITHUB_ENV
+          echo "VERBENA_DATABASE_USER=root" >> $GITHUB_ENV
+          echo "VERBENA_DATABASE_PASSWORD=password" >> $GITHUB_ENV
 
       - name: Save committed schema
         run: |


### PR DESCRIPTION
CI の設定をします。まずは手動で動かす rspec のジョブのみを追加します。

schema.rb は MySQL 専用なので、ほかの DB の時はそれを使わないようにしてください。

This pull request introduces a new GitHub Actions workflow to run RSpec tests across multiple database backends, improving CI reliability and coverage. The workflow is designed to ensure that tests pass consistently with MySQL (via MariaDB), PostgreSQL, and SQLite, regardless of the database used locally or in production.

**Continuous Integration improvements:**

* Added a new `.github/workflows/rspec.yml` workflow that runs RSpec tests manually against three database services: MariaDB (MySQL-compatible), PostgreSQL, and SQLite, each with its own job configuration.
* Ensured that the test databases are always built via migrations rather than schema loading, which avoids issues due to the project's MySQL-centric `db/schema.rb` and improves reliability across different database engines.
* Each job installs necessary system packages (`default-libmysqlclient-dev`, `libpq-dev`, `libsqlite3-dev`) to support all database adapters.
* Environment variables and database setup steps are tailored for each database backend, ensuring correct configuration and isolation between jobs.
* The workflow is triggered manually (`workflow_dispatch`), allowing developers to run cross-database RSpec tests on demand.