### PR TITLE
英語と日本語のローカライズのための I18n サポートを実装

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,3 +16,23 @@ Thanks for your interest!
 5. Open a Pull Request against `develop` and reference the related Issue.
 
 Please keep changes small and focused.
+
+
+# 貢献方法
+
+ご関心をお寄せいただきありがとうございます！
+
+1. まず Issue を作成し、提案内容を議論してください。
+2. リポジトリをフォークしてください。
+3. `develop` ブランチから新しいブランチを作成します。
+
+   git checkout develop
+   git checkout -b your-feature
+
+4. テスト（RSpec）を追加・更新し、すべてのテストがパスすることを確認してください。
+
+   bin/rspec
+
+5. `develop` ブランチ宛てに Pull Request を作成し、関連する Issue を参照してください。
+
+変更は小さく、焦点を絞って行ってください。

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ ruby "3.4.8"
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 8.1", ">= 8.1.2"
+gem "rails-i18n", "~> 8.1"
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem "sprockets-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -236,6 +236,9 @@ GEM
     rails-html-sanitizer (1.6.2)
       loofah (~> 2.21)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    rails-i18n (8.1.0)
+      i18n (>= 0.7, < 2)
+      railties (>= 8.0.0, < 9)
     railties (8.1.2)
       actionpack (= 8.1.2)
       activesupport (= 8.1.2)
@@ -347,6 +350,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 6.4)
   rails (~> 8.1, >= 8.1.2)
+  rails-i18n (~> 8.1)
   rspec-rails (~> 6.0.0)
   simplecov
   solid_queue (~> 1.3)

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,180 @@
+# Verbena
+
+Verbena は、複数のクライアントアプリケーションから EML 形式のメールを受け取り、外部 SMTP サーバへの配送と結果記録を一元管理する**メール配送ゲートウェイ**です。
+
+## 目的
+
+Verbena は各クライアントの「メールを配送する」責務を分離するための独立したアプリケーションです。クライアントは EML を Verbena に渡すだけで、配送の実行・記録・再試行を Verbena 側に委譲できます。
+
+ただし SMTP サーバへの引き渡しまでを責務としており、最終的な受信箱への到達やバウンス管理は対象外です。
+
+**解決する課題：**
+
+- クライアントごとに実装・運用している外部 SMTP との通信や失敗時の取り扱いを一元化したい
+- 複数宛先への送信で一部が失敗した場合、失敗した宛先だけを正確に把握して再送したい
+
+**提供する機能：**
+
+- **配送責務の分離**: クライアントは EML を渡すだけ。配送・再送・記録は Verbena が担当
+- **宛先単位の管理**: 複数宛先への送信を個別に記録し、失敗した宛先のみ再送可能
+- **自動再送**: 一時エラー時の再送をバックグラウンドジョブで自動処理
+- **配送予約**: 指定時刻まで配送を待機
+
+## 準備
+
+### 1. トークンの作成
+
+EML登録（Rake/Web API）には Bearer トークン認証が必要です。管理者が利用者ごとにトークンを発行します：
+
+```ruby
+Token.create_unique!(label: "client-name", key: "secret-key", expires_at: 1.year.from_now)
+```
+
+**運用上の注意:**
+- トークンの発行・更新は管理者のみが行います。利用者は配布された `key` のみ使用し、作成や更新はできません。
+- 発行後の `key` の更新は禁止されています。変更が必要な場合は既存トークンを `revoke!` して無効化し、新しいトークンを作成してください。
+- 期限切れトークンの一括無効化は Rake タスク `verbena:tokens:revoke_expired` を利用してください。
+
+### 2. 環境変数の設定
+
+主要な設定項目：
+
+| 変数名 | 説明 | 既定値 |
+|--------|------|--------|
+| `VERBENA_DELIVERY_METHOD` | 配送方式 (smtp/test/file) | test (開発) / smtp (本番) |
+| `VERBENA_DELIVERY_SMTP_ADDRESS` | SMTP サーバアドレス | - |
+| `VERBENA_DELIVERY_SMTP_PORT` | SMTP ポート | - |
+| `VERBENA_DELIVERY_SMTP_USER_NAME` | SMTP 認証ユーザ | - |
+| `VERBENA_DELIVERY_SMTP_PASSWORD` | SMTP 認証パスワード | - |
+
+全項目は [docs/ENVIRONMENT_VARIABLES.ja.md](docs/ENVIRONMENT_VARIABLES.ja.md) を参照してください。
+
+
+## 使い方
+
+### サーバーの起動
+
+Verbena を起動するには以下のコマンドを実行します：
+
+```sh
+$ bin/dev
+```
+
+このコマンドで Rails サーバーと配送処理のためのバックグラウンドジョブプロセスが同時に起動します。
+
+### メール入力
+
+EML 形式のメールはそのまま `eml_sources` テーブルに保存され、同時に各宛先ごとに配送キュー（`mail_queues` テーブルのレコード）が作成されます。
+
+登録方法は 2 つあります：
+
+**Rake タスク経由**
+
+```sh
+# 環境変数でトークンを指定
+$ VERBENA_TOKEN=your-secret-key bin/rails verbena:mail_queues:add[/path/to/source.eml]
+
+# または引数でトークンを指定
+$ bin/rails verbena:mail_queues:add[/path/to/source.eml,token:your-secret-key]
+```
+
+**Web API 経由**
+
+```sh
+$ curl -H 'Authorization: Bearer your-token' -X POST \
+    -F 'mail_queue[eml]=@/path/to/source.eml' \
+    http://localhost:23000/api/v1/mail_queues
+```
+
+EML のヘッダ `To:`, `Cc:`, `Bcc:` に記載された各宛先ごとに `mail_queues` レコードが作成されます（重複は除外）。
+
+また、ヘッダ `Date:` の値は「配送予約時刻」として同テーブルの `timer_at` 列に格納されます。
+
+### メール配送
+
+配送は SolidQueue バックグラウンドジョブが自動実行します。`timer_at` が経過したレコードが順次処理され、結果は `delivery_responses` テーブルに記録されます。
+
+開発環境では `VERBENA_DELIVERY_METHOD=test` のため実際の送信は行われません。
+
+## ジョブ管理画面
+
+ジョブ管理には Mission Control Jobs を利用します。Basic 認証（環境変数 `VERBENA_ADMIN_USERNAME` / `VERBENA_ADMIN_PASSWORD` で設定）が必要です。
+
+http://localhost:23000/admin/jobs
+
+
+## メンテナンス
+
+### 古いレコードの削除
+
+配送済みレコードは蓄積し続けるため、定期的に削除してください：
+
+```sh
+# 一週間経過したレコードを削除
+$ bin/rails verbena:cleanup:weekly
+
+# TTL（既定30日）で削除
+$ VERBENA_CLEANUP_TTL_DAYS=45 bin/rails verbena:cleanup:by_ttl
+
+# ドライラン（削除件数のみ確認）
+$ bin/rails verbena:cleanup:weekly[true]
+```
+
+### 手動再送（トラブルシューティング）
+
+通常は配送失敗時に自動で再送処理（バックグラウンドジョブによるリトライ）が行われます。
+自動再送の上限を超えた場合や、管理者判断で再送したい場合は、下記の手動コマンドを利用できます。
+
+#### 1. 4xx系一時エラーの再送
+
+直近の配送結果が4xx系（一時的エラー）のメッセージのみを再送キューに入れます。5xx系（恒久的エラー）は対象外です。
+
+```sh
+$ bin/rails verbena:delivery:prepare_retry
+```
+
+> **注意:** 5xx系エラーは恒久的なため、復旧の前に原因を確認し、必要に応じて新しいメッセージを登録してください。
+
+#### 2. 未配送メッセージのリセット
+
+配送結果が1件も存在しない（24時間以上配送されていない）メッセージをリセットします。エラー種別は関係ありません。
+
+```sh
+$ bin/rails verbena:delivery:reset_undelivered
+```
+
+## 開発
+
+### クイックスタート
+
+```sh
+# リポジトリをクローン
+$ git clone https://github.com/hiroaki/Verbena.git
+$ cd Verbena
+
+# 環境変数ファイルを作成
+$ cp dot.env.sample .env
+
+# データベースを選択してコンテナを起動（MySQL の例）
+$ docker compose -f compose.yml -f compose.mysql.yml build
+$ docker compose -f compose.yml -f compose.mysql.yml up -d
+
+# データベースを初期化
+$ docker compose -f compose.yml -f compose.mysql.yml exec web rails db:migrate:reset
+
+# テスト実行
+$ docker compose -f compose.yml -f compose.mysql.yml exec web bundle exec rspec
+```
+
+**対応データベース**: MySQL 8.0+, MariaDB 10.6+, PostgreSQL 13+, SQLite 3.x
+
+### 詳細ドキュメント
+
+開発環境の詳細、アーキテクチャ設計、技術的な意思決定については以下を参照してください：
+
+- **[docs/DEVELOPMENT.ja.md](docs/DEVELOPMENT.ja.md)** - 開発環境構築、テスト、アーキテクチャ、データベース設計
+- **[CONTRIBUTING.md](CONTRIBUTING.md)** - 貢献ガイドライン
+
+## ライセンス
+
+This project is licensed under the 0BSD license. See [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,85 +1,84 @@
 # Verbena
 
-Verbena は、複数のクライアントアプリケーションから EML 形式のメールを受け取り、外部 SMTP サーバへの配送と結果記録を一元管理する**メール配送ゲートウェイ**です。
+Verbena is an **email delivery gateway** that receives EML-format emails from multiple client applications, manages delivery to external SMTP servers, and centrally records the results.
 
-## 目的
+## Purpose
 
-Verbena は各クライアントの「メールを配送する」責務を分離するための独立したアプリケーションです。クライアントは EML を Verbena に渡すだけで、配送の実行・記録・再試行を Verbena 側に委譲できます。
+Verbena is an independent application designed to separate the responsibility of "sending emails" from each client. Clients simply pass EML files to Verbena, and Verbena handles delivery, logging, and retries.
 
-ただし SMTP サーバへの引き渡しまでを責務としており、最終的な受信箱への到達やバウンス管理は対象外です。
+Note: Verbena is responsible only up to handing off to the SMTP server. Final inbox delivery and bounce management are out of scope.
 
-**解決する課題：**
+**Problems Solved:**
 
-- クライアントごとに実装・運用している外部 SMTP との通信や失敗時の取り扱いを一元化したい
-- 複数宛先への送信で一部が失敗した場合、失敗した宛先だけを正確に把握して再送したい
+- Centralizes communication with external SMTP servers and error handling, which would otherwise be implemented and operated by each client.
+- Enables accurate identification and resending of failed recipients when sending to multiple addresses.
 
-**提供する機能：**
+**Features Provided:**
 
-- **配送責務の分離**: クライアントは EML を渡すだけ。配送・再送・記録は Verbena が担当
-- **宛先単位の管理**: 複数宛先への送信を個別に記録し、失敗した宛先のみ再送可能
-- **自動再送**: 一時エラー時の再送をバックグラウンドジョブで自動処理
-- **配送予約**: 指定時刻まで配送を待機
+- **Separation of delivery responsibility**: Clients only need to provide EML files. Delivery, retry, and logging are handled by Verbena.
+- **Per-recipient management**: Each recipient in a multi-address send is logged individually, and only failed recipients can be resent.
+- **Automatic retry**: Temporary errors are automatically retried by background jobs.
+- **Scheduled delivery**: Delivery can be delayed until a specified time.
 
-## 準備
+## Setup
 
-### 1. トークンの作成
+### 1. Token Creation
 
-EML登録（Rake/Web API）には Bearer トークン認証が必要です。管理者が利用者ごとにトークンを発行します：
+Bearer token authentication is required for EML registration (via Rake/Web API). Administrators issue tokens for each user:
 
 ```ruby
 Token.create_unique!(label: "client-name", key: "secret-key", expires_at: 1.year.from_now)
 ```
 
+**Operational Notes:**
+- Only administrators can issue or update tokens. Users may only use the distributed `key` and cannot create or update tokens themselves.
+- Updating a `key` after issuance is prohibited. If a change is needed, revoke the existing token with `revoke!` and create a new one.
+- To bulk-revoke expired tokens, use the Rake task `verbena:tokens:revoke_expired`.
 
-**運用上の注意:**
-- トークンの発行・更新は管理者のみが行います。利用者は配布された `key` のみ使用し、作成や更新はできません。
-- 発行後の `key` の更新は禁止されています。変更が必要な場合は既存トークンを `revoke!` して無効化し、新しいトークンを作成してください。
-- 期限切れトークンの一括無効化は Rake タスク `verbena:tokens:revoke_expired` を利用してください。
+### 2. Environment Variable Configuration
 
-### 2. 環境変数の設定
+Key configuration items:
 
-主要な設定項目：
+| Variable Name | Description | Default |
+|---------------|-------------|---------|
+| `VERBENA_DELIVERY_METHOD` | Delivery method (smtp/test/file) | test (development) / smtp (production) |
+| `VERBENA_DELIVERY_SMTP_ADDRESS` | SMTP server address | - |
+| `VERBENA_DELIVERY_SMTP_PORT` | SMTP port | - |
+| `VERBENA_DELIVERY_SMTP_USER_NAME` | SMTP authentication user | - |
+| `VERBENA_DELIVERY_SMTP_PASSWORD` | SMTP authentication password | - |
 
-| 変数名 | 説明 | 既定値 |
-|--------|------|--------|
-| `VERBENA_DELIVERY_METHOD` | 配送方式 (smtp/test/file) | test (開発) / smtp (本番) |
-| `VERBENA_DELIVERY_SMTP_ADDRESS` | SMTP サーバアドレス | - |
-| `VERBENA_DELIVERY_SMTP_PORT` | SMTP ポート | - |
-| `VERBENA_DELIVERY_SMTP_USER_NAME` | SMTP 認証ユーザ | - |
-| `VERBENA_DELIVERY_SMTP_PASSWORD` | SMTP 認証パスワード | - |
-
-全項目は [docs/ENVIRONMENT_VARIABLES.md](docs/ENVIRONMENT_VARIABLES.md) を参照してください。
+See [docs/ENVIRONMENT_VARIABLES.md](docs/ENVIRONMENT_VARIABLES.md) for all items.
 
 
-## 使い方
+## Usage
 
-### サーバーの起動
+### Starting the Server
 
-Verbena を起動するには以下のコマンドを実行します：
+To start Verbena, run the following command:
 
 ```sh
 $ bin/dev
 ```
 
-このコマンドで Rails サーバーと配送処理のためのバックグラウンドジョブプロセスが同時に起動します。
+This command starts both the Rails server and the background job process for delivery handling.
 
-### メール入力
+### Email Input
 
-EML 形式のメールはそのまま `eml_sources` テーブルに保存され、同時に各宛先ごとに配送キュー（`mail_queues` テーブルのレコード）が作成されます。
+EML-format emails are saved as-is to the `eml_sources` table, and delivery queues (records in the `mail_queues` table) are created for each recipient.
 
-登録方法は 2 つあります：
+There are two ways to register emails:
 
-**Rake タスク経由**
+**Via Rake Task**
 
 ```sh
-# 環境変数でトークンを指定
+# Specify the token via environment variable
 $ VERBENA_TOKEN=your-secret-key bin/rails verbena:mail_queues:add[/path/to/source.eml]
 
-# または引数でトークンを指定
+# Or specify the token as an argument
 $ bin/rails verbena:mail_queues:add[/path/to/source.eml,token:your-secret-key]
 ```
 
-**Web API 経由**
+**Via Web API**
 
 ```sh
 $ curl -H 'Authorization: Bearer your-token' -X POST \
@@ -87,96 +86,94 @@ $ curl -H 'Authorization: Bearer your-token' -X POST \
     http://localhost:23000/api/v1/mail_queues
 ```
 
-EML のヘッダ `To:`, `Cc:`, `Bcc:` に記載された各宛先ごとに `mail_queues` レコードが作成されます（重複は除外）。
+For each recipient listed in the EML headers `To:`, `Cc:`, and `Bcc:`, a `mail_queues` record is created (duplicates are excluded).
 
-また、ヘッダ `Date:` の値は「配送予約時刻」として同テーブルの `timer_at` 列に格納されます。
+The value of the `Date:` header is stored in the `timer_at` column of the same table as the "scheduled delivery time".
 
-### メール配送
+### Email Delivery
 
-配送は SolidQueue バックグラウンドジョブが自動実行します。`timer_at` が経過したレコードが順次処理され、結果は `delivery_responses` テーブルに記録されます。
+Delivery is automatically performed by SolidQueue background jobs. Records whose `timer_at` has passed are processed in order, and results are recorded in the `delivery_responses` table.
 
-開発環境では `VERBENA_DELIVERY_METHOD=test` のため実際の送信は行われません。
+In development, no actual sending occurs because `VERBENA_DELIVERY_METHOD=test`.
 
-## ジョブ管理画面
+## Job Management UI
 
-ジョブ管理には Mission Control Jobs を利用します。Basic 認証（環境変数 `VERBENA_ADMIN_USERNAME` / `VERBENA_ADMIN_PASSWORD` で設定）が必要です。
+Mission Control Jobs is used for job management. Basic authentication (set via environment variables `VERBENA_ADMIN_USERNAME` / `VERBENA_ADMIN_PASSWORD`) is required.
 
 http://localhost:23000/admin/jobs
 
 
-## メンテナンス
+## Maintenance
 
-### 古いレコードの削除
+### Deleting Old Records
 
-配送済みレコードは蓄積し続けるため、定期的に削除してください：
+Delivered records accumulate over time, so please delete them periodically:
 
 ```sh
-# 一週間経過したレコードを削除
+# Delete records older than one week
 $ bin/rails verbena:cleanup:weekly
 
-# TTL（既定30日）で削除
+# Delete by TTL (default 30 days)
 $ VERBENA_CLEANUP_TTL_DAYS=45 bin/rails verbena:cleanup:by_ttl
 
-# ドライラン（削除件数のみ確認）
+# Dry run (check only the number of records to be deleted)
 $ bin/rails verbena:cleanup:weekly[true]
 ```
 
-### 手動再送（トラブルシューティング）
+### Manual Retry (Troubleshooting)
 
-通常は配送失敗時に自動で再送処理（バックグラウンドジョブによるリトライ）が行われます。
-自動再送の上限を超えた場合や、管理者判断で再送したい場合は、下記の手動コマンドを利用できます。
+Normally, failed deliveries are automatically retried by background jobs. If the automatic retry limit is exceeded or an administrator wants to retry, use the following manual commands.
 
-#### 1. 4xx系一時エラーの再送
+#### 1. Retry Temporary 4xx Errors
 
-直近の配送結果が4xx系（一時的エラー）のメッセージのみを再送キューに入れます。5xx系（恒久的エラー）は対象外です。
+Only messages whose most recent delivery result was a 4xx (temporary error) are added to the retry queue. 5xx (permanent errors) are excluded.
 
 ```sh
 $ bin/rails verbena:delivery:prepare_retry
 ```
 
-> **注意:** 5xx系エラーは恒久的なため、復旧の前に原因を確認し、必要に応じて新しいメッセージを登録してください。
+> **Note:** 5xx errors are permanent. Please check the cause before recovery and register a new message if necessary.
 
-#### 2. 未配送メッセージのリセット
+#### 2. Reset Undelivered Messages
 
-配送結果が1件も存在しない（24時間以上配送されていない）メッセージをリセットします。エラー種別は関係ありません。
+Resets messages that have no delivery result (not delivered for over 24 hours), regardless of error type.
 
 ```sh
 $ bin/rails verbena:delivery:reset_undelivered
 ```
 
-## 開発
+## Development
 
-### クイックスタート
+### Quick Start
 
 ```sh
-# リポジトリをクローン
+# Clone the repository
 $ git clone https://github.com/hiroaki/Verbena.git
 $ cd Verbena
 
-# 環境変数ファイルを作成
+# Create environment variable file
 $ cp dot.env.sample .env
 
-# データベースを選択してコンテナを起動（MySQL の例）
+# Select database and start containers (example: MySQL)
 $ docker compose -f compose.yml -f compose.mysql.yml build
 $ docker compose -f compose.yml -f compose.mysql.yml up -d
 
-# データベースを初期化
+# Initialize the database
 $ docker compose -f compose.yml -f compose.mysql.yml exec web rails db:migrate:reset
 
-# テスト実行
+# Run tests
 $ docker compose -f compose.yml -f compose.mysql.yml exec web bundle exec rspec
 ```
 
-**対応データベース**: MySQL 8.0+, MariaDB 10.6+, PostgreSQL 13+, SQLite 3.x
+**Supported Databases**: MySQL 8.0+, MariaDB 10.6+, PostgreSQL 13+, SQLite 3.x
 
-### 詳細ドキュメント
+### Further Documentation
 
-開発環境の詳細、アーキテクチャ設計、技術的な意思決定については以下を参照してください：
+For details on development environment, architecture, and technical decisions, see:
 
-- **[docs/DEVELOPMENT.md](docs/DEVELOPMENT.md)** - 開発環境構築、テスト、アーキテクチャ、データベース設計
-- **[CONTRIBUTING.md](CONTRIBUTING.md)** - 貢献ガイドライン
----
+- **[docs/DEVELOPMENT.md](docs/DEVELOPMENT.md)** - Development environment setup, testing, architecture, database design
+- **[CONTRIBUTING.md](CONTRIBUTING.md)** - Contribution guidelines
 
-## ライセンス
+## License
 
 This project is licensed under the 0BSD license. See [LICENSE](LICENSE).

--- a/app/controllers/eml_inputs_controller.rb
+++ b/app/controllers/eml_inputs_controller.rb
@@ -30,17 +30,17 @@ class EmlInputsController < ApplicationController
 
     # Try to extract created MailQueue IDs from the API response body (JSON)
     results = parse_results!(response.body)
-    notice = "送信しました (作成ID: #{results.join(',')})"
+    notice = I18n.t("flash.eml_inputs.sent", ids: results.join(','))
 
     flash[:notice] = notice
     redirect_to new_eml_input_path
   rescue InputError, Verbena::HttpDelivery::DeliveryError => ex
     Rails.logger.warn("eml.inputs#create user error: #{ex.class}: #{ex.message}")
-    flash.now[:alert] = "送信に失敗しました: #{ex.message}"
+    flash.now[:alert] = I18n.t("flash.eml_inputs.failed", error: ex.message)
     render_error_restoring_inputs
   rescue => ex
     Rails.logger.error("eml.inputs#create unexpected error: #{ex.class}: #{ex.message}\n#{ex.backtrace.join("\n")}")
-    flash.now[:alert] = "システムエラーが発生しました"
+    flash.now[:alert] = I18n.t("flash.eml_inputs.system_error")
     render_error_restoring_inputs
   end
 
@@ -92,17 +92,17 @@ class EmlInputsController < ApplicationController
   end
 
   def validate_token!(token)
-    raise InputError, 'Tokenを入力してください' if token.blank?
+    raise InputError, I18n.t("errors.eml_inputs.token_blank") if token.blank?
   end
 
   def validate_eml_file!(upload)
-    raise InputError, 'EMLファイルを選択してください' unless upload.present?
+    raise InputError, I18n.t("errors.eml_inputs.upload_blank") unless upload.present?
 
     # 拡張子チェック（ブラウザ側の accept 属性はあてにならないためサーバ側でも確認）
     if upload.respond_to?(:original_filename)
       fname = upload.original_filename.to_s
       if File.extname(fname).downcase != '.eml'
-        raise InputError, 'EMLファイル（.eml）を選択してください'
+        raise InputError, I18n.t("errors.eml_inputs.upload_ext")
       end
     end
 
@@ -113,17 +113,17 @@ class EmlInputsController < ApplicationController
     max_size = MAX_EML_UPLOAD_SIZE
 
     if upload.respond_to?(:size) && !upload.size.nil?
-      raise InputError, 'EMLが空です' if upload.size.to_i == 0
-      raise InputError, "EMLファイルが大きすぎます (最大 #{max_size} バイト)" if upload.size.to_i > max_size
+      raise InputError, I18n.t("errors.eml_inputs.eml_empty") if upload.size.to_i == 0
+      raise InputError, I18n.t("errors.eml_inputs.eml_too_large", max: max_size) if upload.size.to_i > max_size
     else
       if upload.respond_to?(:read)
         content = upload.read(max_size + 1)
-        raise InputError, 'EMLが空です' if content.blank?
-        raise InputError, 'EMLファイルが大きすぎます' if content.bytesize > max_size
+        raise InputError, I18n.t("errors.eml_inputs.eml_empty") if content.blank?
+        raise InputError, I18n.t("errors.eml_inputs.eml_too_large_simple") if content.bytesize > max_size
         upload.rewind if upload.respond_to?(:rewind)
       else
         content = upload.to_s
-        raise InputError, 'EMLが空です' if content.blank?
+        raise InputError, I18n.t("errors.eml_inputs.eml_empty") if content.blank?
       end
     end
   end
@@ -143,7 +143,7 @@ class EmlInputsController < ApplicationController
     @token = params[:token]
     @sent_at = params[:sent_at]
 
-    flash.now[:alert] ||= "送信に失敗しました"
+    flash.now[:alert] ||= I18n.t("flash.eml_inputs.failed_generic")
     render :new, status: :unprocessable_entity
   end
 
@@ -194,7 +194,7 @@ class EmlInputsController < ApplicationController
     return [] if raw.blank?
     Mail::AddressList.new(raw.to_s).addresses.map(&:address).reject(&:blank?)
   rescue Mail::Field::ParseError
-    raise InputError, '不正なメールアドレス形式が含まれています'
+    raise InputError, I18n.t("errors.eml_inputs.invalid_address")
   end
 
   def fields_params

--- a/app/views/eml_inputs/_form_body.html.erb
+++ b/app/views/eml_inputs/_form_body.html.erb
@@ -1,12 +1,12 @@
 <%# Combined form body partial. locals: fields_values, token, sent_at %>
 
-<h2 class="subtitle">EMLファイルをアップロード、または各項目を入力して送信します。</h2>
+<h2 class="subtitle"><%= t("pages.eml_inputs.subtitle") %></h2>
 
 <div class="box">
   <!-- Upload first -->
   <div class="field is-horizontal">
     <div class="field-label is-normal">
-      <%= label_tag 'upload[eml_file]', 'EMLファイル', class: 'label' %>
+      <%= label_tag 'upload[eml_file]', t("pages.eml_inputs.labels.eml_file"), class: 'label' %>
     </div>
     <div class="field-body">
       <div class="field">
@@ -22,66 +22,66 @@
   <!-- Fields to build EML when no upload -->
   <div class="field is-horizontal">
     <div class="field-label is-normal">
-      <%= label_tag 'fields[from]', 'From', class: 'label' %>
+      <%= label_tag 'fields[from]', t("pages.eml_inputs.labels.from"), class: 'label' %>
     </div>
     <div class="field-body">
       <div class="field"><div class="control">
-        <%= text_field_tag 'fields[from]', fields_values[:from], placeholder: 'sender@example.com', class: 'input' %>
+        <%= text_field_tag 'fields[from]', fields_values[:from], placeholder: t("pages.eml_inputs.placeholders.from"), class: 'input' %>
       </div></div>
     </div>
   </div>
 
   <div class="field is-horizontal">
     <div class="field-label is-normal">
-      <%= label_tag 'fields[to]', 'To', class: 'label' %>
+      <%= label_tag 'fields[to]', t("pages.eml_inputs.labels.to"), class: 'label' %>
     </div>
     <div class="field-body">
       <div class="field"><div class="control">
-        <%= text_field_tag 'fields[to]', fields_values[:to], placeholder: 'user@example.com, other@example.com', class: 'input' %>
+        <%= text_field_tag 'fields[to]', fields_values[:to], placeholder: t("pages.eml_inputs.placeholders.to"), class: 'input' %>
       </div></div>
     </div>
   </div>
 
   <div class="field is-horizontal">
     <div class="field-label is-normal">
-      <%= label_tag 'fields[cc]', 'Cc', class: 'label' %>
+      <%= label_tag 'fields[cc]', t("pages.eml_inputs.labels.cc"), class: 'label' %>
     </div>
     <div class="field-body">
       <div class="field"><div class="control">
-        <%= text_field_tag 'fields[cc]', fields_values[:cc], placeholder: 'cc@example.com', class: 'input' %>
+        <%= text_field_tag 'fields[cc]', fields_values[:cc], placeholder: t("pages.eml_inputs.placeholders.cc"), class: 'input' %>
       </div></div>
     </div>
   </div>
 
   <div class="field is-horizontal">
     <div class="field-label is-normal">
-      <%= label_tag 'fields[bcc]', 'Bcc', class: 'label' %>
+      <%= label_tag 'fields[bcc]', t("pages.eml_inputs.labels.bcc"), class: 'label' %>
     </div>
     <div class="field-body">
       <div class="field"><div class="control">
-        <%= text_field_tag 'fields[bcc]', fields_values[:bcc], placeholder: 'bcc@example.com', class: 'input' %>
+        <%= text_field_tag 'fields[bcc]', fields_values[:bcc], placeholder: t("pages.eml_inputs.placeholders.bcc"), class: 'input' %>
       </div></div>
     </div>
   </div>
 
   <div class="field is-horizontal">
     <div class="field-label is-normal">
-      <%= label_tag 'fields[subject]', 'Subject', class: 'label' %>
+      <%= label_tag 'fields[subject]', t("pages.eml_inputs.labels.subject"), class: 'label' %>
     </div>
     <div class="field-body">
       <div class="field"><div class="control">
-        <%= text_field_tag 'fields[subject]', fields_values[:subject], placeholder: 'Subject text', class: 'input' %>
+        <%= text_field_tag 'fields[subject]', fields_values[:subject], placeholder: t("pages.eml_inputs.placeholders.subject"), class: 'input' %>
       </div></div>
     </div>
   </div>
 
   <div class="field is-horizontal">
     <div class="field-label is-normal">
-      <%= label_tag 'fields[body]', '本文', class: 'label' %>
+      <%= label_tag 'fields[body]', t("pages.eml_inputs.labels.body"), class: 'label' %>
     </div>
     <div class="field-body">
       <div class="field"><div class="control">
-        <%= text_area_tag 'fields[body]', fields_values[:body], rows: 6, placeholder: '本文を入力してください', class: 'textarea' %>
+        <%= text_area_tag 'fields[body]', fields_values[:body], rows: 6, placeholder: t("pages.eml_inputs.placeholders.body"), class: 'textarea' %>
       </div></div>
     </div>
   </div>
@@ -91,26 +91,26 @@
 <div class="box">
   <div class="field is-horizontal">
     <div class="field-label is-normal">
-      <%= label_tag :sent_at, '送信日時', class: 'label' %>
+      <%= label_tag :sent_at, t("pages.eml_inputs.labels.sent_at"), class: 'label' %>
     </div>
     <div class="field-body">
       <div class="field">
         <div class="control">
           <%= datetime_local_field_tag :sent_at, sent_at, class: 'input' %>
         </div>
-        <p class="help">※フィールド入力時は未指定なら現在時刻になります。アップロード時は未指定ならEML内のDateが使われます。</p>
+        <p class="help"><%= t("pages.eml_inputs.help.sent_at") %></p>
       </div>
     </div>
   </div>
 
   <div class="field is-horizontal">
     <div class="field-label is-normal">
-      <%= label_tag :token, 'Token (Authorization)', class: 'label' %>
+      <%= label_tag :token, t("pages.eml_inputs.labels.token"), class: 'label' %>
     </div>
     <div class="field-body">
       <div class="field">
         <div class="control">
-          <%= text_field_tag :token, token, placeholder: 'API Token', class: 'input', required: true %>
+          <%= text_field_tag :token, token, placeholder: t("pages.eml_inputs.placeholders.token"), class: 'input', required: true %>
         </div>
       </div>
     </div>
@@ -118,8 +118,8 @@
 
   <div class="field">
     <div class="control">
-      <%= submit_tag '送信', class: 'button is-primary is-fullwidth' %>
+      <%= submit_tag t("pages.eml_inputs.actions.submit"), class: 'button is-primary is-fullwidth' %>
     </div>
-    <p class="help">※EMLファイルがアップロードされている場合はそちらが優先されます</p>
+    <p class="help"><%= t("pages.eml_inputs.help.upload_priority") %></p>
   </div>
 </div>

--- a/app/views/eml_inputs/new.html.erb
+++ b/app/views/eml_inputs/new.html.erb
@@ -1,6 +1,6 @@
 <section class="section">
   <div class="container">
-    <h1 class="title">EML投入（デモ用）</h1>
+    <h1 class="title"><%= t("pages.eml_inputs.title") %></h1>
 
     <%= render partial: 'eml_inputs/flash', locals: { notice: flash[:notice], alert: flash[:alert] } %>
 

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -1,1 +1,1 @@
-<h1>TOPページ</h1>
+<h1><%= t("pages.top.title") %></h1>

--- a/config/application.rb
+++ b/config/application.rb
@@ -39,6 +39,12 @@ module Verbena
     # Don't generate system test files.
     config.generators.system_tests = nil
 
+    # I18n base configuration
+    config.i18n.available_locales = %i[en ja]
+    config.i18n.default_locale = :en
+    # Use English as a fallback when running in Japanese.
+    config.i18n.fallbacks = { ja: [:ja, :en], en: [:en] }
+
     #----------
     # 追加設定
     #

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -68,9 +68,10 @@ Rails.application.configure do
   #   authentication: :plain
   # }
 
-  # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
-  # the I18n.default_locale when a translation cannot be found).
-  config.i18n.fallbacks = true
+  # # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
+  # # the I18n.default_locale when a translation cannot be found).
+  # config.i18n.fallbacks = true
+  #--> Locale fallbacks are configured in config/application.rb.
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,3 +45,37 @@ en:
       eml_too_large: "EML file is too large (max %{max} bytes)."
       eml_too_large_simple: "EML file is too large."
       invalid_address: "Invalid email address format is included."
+  activerecord:
+    models:
+      token: "Token"
+      mail_queue: "Mail queue"
+      eml_source: "EML source"
+    attributes:
+      token:
+        label: "Label"
+        key: "Key"
+        expires_at: "Expires at"
+        revoked_at: "Revoked at"
+        last_used_at: "Last used at"
+        key_digest_hash: "Key digest"
+      mail_queue:
+        timer_at: "Scheduled at"
+        envelope_from: "Envelope from"
+        envelope_to: "Envelope to"
+        delivery_status: "Delivery status"
+        attempts_count: "Attempts"
+        last_attempted_at: "Last attempted at"
+        locked_until: "Locked until"
+        claimed_at: "Claimed at"
+        token: "Token"
+        eml_source: "EML source"
+      eml_source:
+        eml: "EML"
+    errors:
+      models:
+        token:
+          attributes:
+            key:
+              invalid: "cannot be changed; revoke and recreate instead"
+            base:
+              taken: "has already been taken"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,33 +1,47 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t "hello"
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t("hello") %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# The following keys must be escaped otherwise they will not be retrieved by
-# the default I18n backend:
-#
-# true, false, on, off, yes, no
-#
-# Instead, surround them with single quotes.
-#
-# en:
-#   "true": "foo"
-#
-# To learn more, please read the Rails Internationalization guide
-# available at https://guides.rubyonrails.org/i18n.html.
-
 en:
-  hello: "Hello world"
+  app:
+    name: "Verbena"
+  pages:
+    top:
+      title: "Top"
+    eml_inputs:
+      title: "EML Input (Demo)"
+      subtitle: "Upload an EML file or fill the fields to send."
+      labels:
+        eml_file: "EML file"
+        from: "From"
+        to: "To"
+        cc: "Cc"
+        bcc: "Bcc"
+        subject: "Subject"
+        body: "Body"
+        sent_at: "Sent at"
+        token: "Token (Authorization)"
+      placeholders:
+        from: "sender@example.com"
+        to: "user@example.com, other@example.com"
+        cc: "cc@example.com"
+        bcc: "bcc@example.com"
+        subject: "Subject text"
+        body: "Enter body text"
+        token: "API Token"
+      help:
+        sent_at: "If omitted in fields mode, uses the current time. If omitted in upload mode, uses the Date in the EML."
+        upload_priority: "If an EML file is uploaded, it takes priority."
+      actions:
+        submit: "Send"
+  flash:
+    eml_inputs:
+      sent: "Sent (created IDs: %{ids})"
+      failed: "Failed to send: %{error}"
+      system_error: "A system error occurred."
+      failed_generic: "Failed to send."
+  errors:
+    eml_inputs:
+      token_blank: "Please enter a token."
+      upload_blank: "Please select an EML file."
+      upload_ext: "Please select an EML file (.eml)."
+      eml_empty: "EML is empty."
+      eml_too_large: "EML file is too large (max %{max} bytes)."
+      eml_too_large_simple: "EML file is too large."
+      invalid_address: "Invalid email address format is included."

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,47 @@
+ja:
+  app:
+    name: "Verbena"
+  pages:
+    top:
+      title: "TOPページ"
+    eml_inputs:
+      title: "EML投入（デモ用）"
+      subtitle: "EMLファイルをアップロード、または各項目を入力して送信します。"
+      labels:
+        eml_file: "EMLファイル"
+        from: "From"
+        to: "To"
+        cc: "Cc"
+        bcc: "Bcc"
+        subject: "Subject"
+        body: "本文"
+        sent_at: "送信日時"
+        token: "Token (Authorization)"
+      placeholders:
+        from: "sender@example.com"
+        to: "user@example.com, other@example.com"
+        cc: "cc@example.com"
+        bcc: "bcc@example.com"
+        subject: "Subject text"
+        body: "本文を入力してください"
+        token: "API Token"
+      help:
+        sent_at: "※フィールド入力時は未指定なら現在時刻になります。アップロード時は未指定ならEML内のDateが使われます。"
+        upload_priority: "※EMLファイルがアップロードされている場合はそちらが優先されます"
+      actions:
+        submit: "送信"
+  flash:
+    eml_inputs:
+      sent: "送信しました (作成ID: %{ids})"
+      failed: "送信に失敗しました: %{error}"
+      system_error: "システムエラーが発生しました"
+      failed_generic: "送信に失敗しました"
+  errors:
+    eml_inputs:
+      token_blank: "Tokenを入力してください"
+      upload_blank: "EMLファイルを選択してください"
+      upload_ext: "EMLファイル（.eml）を選択してください"
+      eml_empty: "EMLが空です"
+      eml_too_large: "EMLファイルが大きすぎます (最大 %{max} バイト)"
+      eml_too_large_simple: "EMLファイルが大きすぎます"
+      invalid_address: "不正なメールアドレス形式が含まれています"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -45,3 +45,37 @@ ja:
       eml_too_large: "EMLファイルが大きすぎます (最大 %{max} バイト)"
       eml_too_large_simple: "EMLファイルが大きすぎます"
       invalid_address: "不正なメールアドレス形式が含まれています"
+  activerecord:
+    models:
+      token: "トークン"
+      mail_queue: "メールキュー"
+      eml_source: "EMLソース"
+    attributes:
+      token:
+        label: "ラベル"
+        key: "キー"
+        expires_at: "有効期限"
+        revoked_at: "無効化日時"
+        last_used_at: "最終使用日時"
+        key_digest_hash: "キーダイジェスト"
+      mail_queue:
+        timer_at: "配信予定日時"
+        envelope_from: "エンベロープFrom"
+        envelope_to: "エンベロープTo"
+        delivery_status: "配信ステータス"
+        attempts_count: "試行回数"
+        last_attempted_at: "最終試行日時"
+        locked_until: "ロック期限"
+        claimed_at: "取得日時"
+        token: "トークン"
+        eml_source: "EMLソース"
+      eml_source:
+        eml: "EML"
+    errors:
+      models:
+        token:
+          attributes:
+            key:
+              invalid: "変更できません。取り消して再作成してください"
+            base:
+              taken: "既に使用されています"

--- a/docs/BOUNCE_MANAGEMENT.ja.md
+++ b/docs/BOUNCE_MANAGEMENT.ja.md
@@ -1,0 +1,268 @@
+(Claude Sonnet 4.5 作成)
+---
+
+# バウンス管理機能の設計
+
+## 概要
+
+このドキュメントは将来実装予定の機能について記述したものです。現在のバージョンには含まれていません。
+
+## なぜバウンス管理が必要か
+
+### 現状の制約
+
+Verbenaは現在「SMTP配送先サーバへの引き渡しまで」を保証しますが、以下のケースは検知できません：
+
+- リレー先サーバでのバウンス（5xx恒久エラー、4xx一時エラー）
+- スパムフィルタによるドロップ
+- メールボックスが満杯で受け取れない
+- ユーザーアカウントが存在しない
+
+### バウンス管理によるメリット
+
+1. **配信効率の向上**: 恒久的に配信不能なアドレスへの無駄な再送を回避
+2. **スパム判定リスクの軽減**: バウンス率が高いとSMTPサーバの信頼性が低下
+3. **運用可視性の向上**: 「どの宛先がなぜ配信不能か」を記録・分析
+4. **データ品質の改善**: 無効なアドレスをデータベースから識別・除外
+
+## アーキテクチャ方針
+
+### 単一アプリ構成（Verbenaに統合）
+
+バウンス管理機能はVerbenaに組み込む方針とします。
+
+**理由**:
+- システム構成がシンプル（DB・デプロイ・管理が一元化）
+- 小〜中規模用途では運用負荷が低い
+- 配信時のブラックリストチェックが容易
+
+**将来の拡張性**:
+- ブラックリスト部分は疎結合に設計し、必要に応じて切り出し可能にする
+- API公開により、他システムからのブラックリスト参照も可能
+- Verbenaの配信機能を使わず、ブラックリスト管理だけを利用することも可能
+
+## 段階的実装計画
+
+### Phase 1: 最小構成（手動運用）
+
+配信前チェックと手動管理の基盤を構築します。
+
+**実装内容**:
+
+1. **`bounced_addresses` テーブル**
+   ```ruby
+   create_table :bounced_addresses do |t|
+     t.string :email, null: false, index: { unique: true }
+     t.string :reason          # 'user_unknown', 'mailbox_full', 'spam_detected' など
+     t.boolean :is_permanent, default: false
+     t.datetime :bounced_at
+     t.text :details           # バウンスメールの詳細（オプション）
+     t.timestamps
+   end
+   ```
+
+2. **配信前チェック機能**
+   - `DeliveryService#perform_one` 内でブラックリストを確認
+   - 該当する場合は配送をスキップし、ログに記録
+   - スキップしたレコードは `DeliveryResponse` に status 550（またはカスタムコード）で記録
+
+3. **管理画面（Rails Admin / ActiveAdmin 等）**
+   - バウンスアドレスの一覧・検索
+   - 手動登録・削除
+   - 理由（reason）の編集
+
+**ゴール**: 運用者が手動でブラックリストを管理し、配信時に参照できる状態
+
+---
+
+### Phase 2: 自動化（Sisimai統合）
+
+バウンスメールの自動解析とブラックリストへの自動登録を実装します。
+
+**実装内容**:
+
+1. **Sisimaiの導入**
+   ```ruby
+   # Gemfile
+   gem 'sisimai'
+   ```
+
+2. **バウンス受信用メールアドレスの設定**
+   - 専用のバウンス受信アドレス（例: `bounce@example.com`）を用意
+   - 配信時の Return-Path をこのアドレスに統一（または VERP で個別化）
+
+3. **バウンス収集・解析バッチ**
+   - cronで定期実行（例: 毎時）
+   - IMAP/POP3 または mbox ファイルからバウンスメールを取得
+   - Sisimaiで解析し、以下を抽出：
+     - バウンスした宛先アドレス
+     - エラー理由（reason）
+     - 恒久的/一時的エラーの判定（deliverystatus）
+   - 恒久的エラー（5xx）は `bounced_addresses` に自動登録
+   - 一時的エラー（4xx）は記録のみ（再送ロジックで対応）
+
+4. **Rakeタスク**
+   ```bash
+   # バウンス収集・解析
+   rails verbena:bounce:collect
+
+   # ドライラン（登録せずに解析結果のみ表示）
+   rails verbena:bounce:collect[true]
+   ```
+
+5. **再送ロジックの改善**
+   - 4xxエラーは一定回数・期間まで再送
+   - 再送上限に達した場合は管理者通知
+
+**ゴール**: バウンスメールを自動解析し、恒久的エラーアドレスをブラックリストに自動登録
+
+---
+
+### Phase 3: 高度化
+
+外部連携やレポート機能を追加します。
+
+**実装内容**:
+
+1. **ブラックリスト参照API**
+   ```ruby
+   # GET /api/v1/bounced_addresses?email=test@example.com
+   # => { "bounced": true, "reason": "user_unknown", "bounced_at": "..." }
+   ```
+
+2. **バウンス統計・レポート**
+   - バウンス率の推移グラフ
+   - 理由別の集計
+   - ドメイン別のバウンス傾向
+
+3. **他システムへの通知**
+   - Webhook: バウンス検出時に外部システムへ通知
+   - Slack/Email通知: 閾値を超えた場合のアラート
+
+4. **ホワイトリスト機能**
+   - 誤検知されたアドレスを除外
+   - 一時的にブラックリストを無効化
+
+**ゴール**: エンタープライズ用途でも使える高機能なバウンス管理基盤
+
+## 技術的考慮事項
+
+### Return-Path の設定
+
+バウンスを確実に受信するため、以下の設定が必要です：
+
+**現状の実装**:
+```ruby
+mail.smtp_envelope_from(mail_queue.envelope_from)
+```
+
+**バウンス管理対応**:
+```ruby
+# 環境変数で指定したバウンス受信用アドレスを使用
+bounce_address = ENV['VERBENA_BOUNCE_ADDRESS'] || mail_queue.envelope_from
+mail.smtp_envelope_from(bounce_address)
+```
+
+または VERP（Variable Envelope Return Path）方式：
+```ruby
+# 配送ごとにユニークなReturn-Pathを生成
+# 例: bounce+12345@example.com (12345 = mail_queue.id)
+verp_address = "bounce+#{mail_queue.id}@example.com"
+mail.smtp_envelope_from(verp_address)
+```
+
+### ブラックリストチェックのタイミング
+
+**推奨**: `DeliveryService#perform_one` 内でチェック
+
+```ruby
+def perform_one(mail_queue)
+  # ブラックリストチェック
+  if BouncedAddress.exists?(email: mail_queue.envelope_to)
+    logger.info("Skipped: #{mail_queue.envelope_to} is blacklisted")
+    mail_queue.delivery_responses.create!(
+      status: 550, # または独自コード 999
+      contents: 'Skipped: address is in bounce blacklist',
+      responded_at: Time.current
+    )
+    return
+  end
+
+  # ... 既存の配送ロジック
+end
+```
+
+この方式のメリット：
+- スキップしたレコードのログが残る
+- 柔軟な判定ロジック（例: 一時エラーは除外、恒久エラーのみブロック）
+
+### Sisimai の使い方（サンプル）
+
+```ruby
+# バウンスメール収集・解析サービス
+class BounceCollectorService
+  def perform
+    # IMAP接続（例）
+    imap = Net::IMAP.new('imap.example.com', 993, true)
+    imap.login('bounce@example.com', 'password')
+    imap.select('INBOX')
+
+    # 未読メールを取得
+    message_ids = imap.search(['UNSEEN'])
+
+    message_ids.each do |msg_id|
+      # メール本文を取得
+      msg = imap.fetch(msg_id, 'RFC822')[0].attr['RFC822']
+
+      # Sisimaiで解析
+      results = Sisimai.make(msg)
+      next if results.nil? || results.empty?
+
+      results.each do |bounce|
+        # 恒久的エラー（5xx）のみブラックリスト登録
+        if bounce.deliverystatus.start_with?('5.')
+          BouncedAddress.find_or_create_by(email: bounce.recipient) do |record|
+            record.reason = bounce.reason
+            record.is_permanent = true
+            record.bounced_at = Time.current
+            record.details = bounce.diagnosticcode
+          end
+
+          Rails.logger.info("Blacklisted: #{bounce.recipient} (#{bounce.reason})")
+        end
+      end
+
+      # 既読にする
+      imap.store(msg_id, '+FLAGS', [:Seen])
+    end
+
+    imap.logout
+    imap.disconnect
+  end
+end
+```
+
+## 運用フロー
+
+### 日常運用（Phase 2 以降）
+
+1. cronでバウンス収集バッチを定期実行（毎時）
+2. 恒久的エラーアドレスが自動的にブラックリスト登録される
+3. 配信時に自動的にスキップされる
+4. 管理画面でバウンス状況を確認・手動調整
+
+### トラブルシューティング
+
+- バウンスが正しく解析されない → Sisimai のログを確認、対応MTAを追加
+- 誤検知でブラックリスト登録された → 管理画面から削除、またはホワイトリスト機能で除外
+- バウンス率が急増 → レポートで原因特定（ドメイン・理由別集計）
+
+## まとめ
+
+バウンス管理機能を段階的に実装することで、Verbenaは「SMTP配送管理」から「実質的な到達性管理」へと進化します。
+
+- **Phase 1**: 最小限の手動管理で即効性
+- **Phase 2**: 自動化で運用負荷削減
+- **Phase 3**: エンタープライズ用途への対応
+
+単一アプリ構成を維持しつつ、疎結合な設計により将来の拡張性も確保します。

--- a/docs/BOUNCE_MANAGEMENT.md
+++ b/docs/BOUNCE_MANAGEMENT.md
@@ -1,225 +1,225 @@
-(Claude Sonnet 4.5 作成)
+(Created by Claude Sonnet 4.5)
 ---
 
-# バウンス管理機能の設計
+# Bounce Management Feature Design
 
-## 概要
+## Overview
 
-このドキュメントは将来実装予定の機能について記述したものです。現在のバージョンには含まれていません。
+This document describes features planned for future implementation. They are not included in the current version.
 
-## なぜバウンス管理が必要か
+## Why Bounce Management Is Needed
 
-### 現状の制約
+### Current Limitations
 
-Verbenaは現在「SMTP配送先サーバへの引き渡しまで」を保証しますが、以下のケースは検知できません：
+Currently, Verbena guarantees "handoff to the destination SMTP server," but cannot detect the following cases:
 
-- リレー先サーバでのバウンス（5xx恒久エラー、4xx一時エラー）
-- スパムフィルタによるドロップ
-- メールボックスが満杯で受け取れない
-- ユーザーアカウントが存在しない
+- Bounces at relay servers (5xx permanent errors, 4xx temporary errors)
+- Drops by spam filters
+- Mailbox full and cannot receive
+- User account does not exist
 
-### バウンス管理によるメリット
+### Benefits of Bounce Management
 
-1. **配信効率の向上**: 恒久的に配信不能なアドレスへの無駄な再送を回避
-2. **スパム判定リスクの軽減**: バウンス率が高いとSMTPサーバの信頼性が低下
-3. **運用可視性の向上**: 「どの宛先がなぜ配信不能か」を記録・分析
-4. **データ品質の改善**: 無効なアドレスをデータベースから識別・除外
+1. **Improved delivery efficiency**: Avoids unnecessary retries to permanently undeliverable addresses
+2. **Reduced spam risk**: High bounce rates lower SMTP server reputation
+3. **Improved operational visibility**: Records and analyzes "which recipients are undeliverable and why"
+4. **Improved data quality**: Identifies and excludes invalid addresses from the database
 
-## アーキテクチャ方針
+## Architecture Policy
 
-### 単一アプリ構成（Verbenaに統合）
+### Single-App Structure (Integrated into Verbena)
 
-バウンス管理機能はVerbenaに組み込む方針とします。
+The bounce management feature will be integrated into Verbena.
 
-**理由**:
-- システム構成がシンプル（DB・デプロイ・管理が一元化）
-- 小〜中規模用途では運用負荷が低い
-- 配信時のブラックリストチェックが容易
+**Reasons:**
+- Simple system structure (DB, deployment, management are unified)
+- Low operational burden for small to medium scale use
+- Easy blacklist checking at delivery time
 
-**将来の拡張性**:
-- ブラックリスト部分は疎結合に設計し、必要に応じて切り出し可能にする
-- API公開により、他システムからのブラックリスト参照も可能
-- Verbenaの配信機能を使わず、ブラックリスト管理だけを利用することも可能
+**Future extensibility:**
+- Design the blacklist part loosely coupled, so it can be separated if needed
+- API publication allows other systems to reference the blacklist
+- Possible to use only blacklist management without using Verbena's delivery features
 
-## 段階的実装計画
+## Phased Implementation Plan
 
-### Phase 1: 最小構成（手動運用）
+### Phase 1: Minimal (Manual Operation)
 
-配信前チェックと手動管理の基盤を構築します。
+Build the foundation for pre-delivery checks and manual management.
 
-**実装内容**:
+**Implementation:**
 
-1. **`bounced_addresses` テーブル**
+1. **`bounced_addresses` table**
    ```ruby
    create_table :bounced_addresses do |t|
      t.string :email, null: false, index: { unique: true }
-     t.string :reason          # 'user_unknown', 'mailbox_full', 'spam_detected' など
+     t.string :reason          # 'user_unknown', 'mailbox_full', 'spam_detected', etc.
      t.boolean :is_permanent, default: false
      t.datetime :bounced_at
-     t.text :details           # バウンスメールの詳細（オプション）
+     t.text :details           # Details of the bounce email (optional)
      t.timestamps
    end
    ```
 
-2. **配信前チェック機能**
-   - `DeliveryService#perform_one` 内でブラックリストを確認
-   - 該当する場合は配送をスキップし、ログに記録
-   - スキップしたレコードは `DeliveryResponse` に status 550（またはカスタムコード）で記録
+2. **Pre-delivery check**
+   - Check the blacklist in `DeliveryService#perform_one`
+   - If matched, skip delivery and log it
+   - Skipped records are recorded in `DeliveryResponse` with status 550 (or custom code)
 
-3. **管理画面（Rails Admin / ActiveAdmin 等）**
-   - バウンスアドレスの一覧・検索
-   - 手動登録・削除
-   - 理由（reason）の編集
+3. **Admin UI (Rails Admin / ActiveAdmin, etc.)**
+   - List/search bounced addresses
+   - Manual add/delete
+   - Edit reason
 
-**ゴール**: 運用者が手動でブラックリストを管理し、配信時に参照できる状態
+**Goal**: Operators can manually manage the blacklist and reference it at delivery time
 
 ---
 
-### Phase 2: 自動化（Sisimai統合）
+### Phase 2: Automation (Sisimai Integration)
 
-バウンスメールの自動解析とブラックリストへの自動登録を実装します。
+Implement automatic parsing of bounce emails and automatic registration to the blacklist.
 
-**実装内容**:
+**Implementation:**
 
-1. **Sisimaiの導入**
+1. **Introduce Sisimai**
    ```ruby
    # Gemfile
    gem 'sisimai'
    ```
 
-2. **バウンス受信用メールアドレスの設定**
-   - 専用のバウンス受信アドレス（例: `bounce@example.com`）を用意
-   - 配信時の Return-Path をこのアドレスに統一（または VERP で個別化）
+2. **Set up bounce receiving email address**
+   - Prepare a dedicated bounce receiving address (e.g., `bounce@example.com`)
+   - Unify Return-Path at delivery to this address (or individualize with VERP)
 
-3. **バウンス収集・解析バッチ**
-   - cronで定期実行（例: 毎時）
-   - IMAP/POP3 または mbox ファイルからバウンスメールを取得
-   - Sisimaiで解析し、以下を抽出：
-     - バウンスした宛先アドレス
-     - エラー理由（reason）
-     - 恒久的/一時的エラーの判定（deliverystatus）
-   - 恒久的エラー（5xx）は `bounced_addresses` に自動登録
-   - 一時的エラー（4xx）は記録のみ（再送ロジックで対応）
+3. **Bounce collection/analysis batch**
+   - Run periodically with cron (e.g., hourly)
+   - Retrieve bounce emails via IMAP/POP3 or from mbox file
+   - Parse with Sisimai and extract:
+     - Bounced recipient address
+     - Error reason
+     - Permanent/temporary error determination (deliverystatus)
+   - Automatically register permanent errors (5xx) to `bounced_addresses`
+   - Record only temporary errors (4xx) (handled by retry logic)
 
-4. **Rakeタスク**
+4. **Rake tasks**
    ```bash
-   # バウンス収集・解析
+   # Collect and analyze bounces
    rails verbena:bounce:collect
 
-   # ドライラン（登録せずに解析結果のみ表示）
+   # Dry run (show analysis results only, no registration)
    rails verbena:bounce:collect[true]
    ```
 
-5. **再送ロジックの改善**
-   - 4xxエラーは一定回数・期間まで再送
-   - 再送上限に達した場合は管理者通知
+5. **Improve retry logic**
+   - Retry 4xx errors up to a certain count/period
+   - Notify admin when retry limit is reached
 
-**ゴール**: バウンスメールを自動解析し、恒久的エラーアドレスをブラックリストに自動登録
+**Goal**: Automatically parse bounce emails and automatically register permanent error addresses to the blacklist
 
 ---
 
-### Phase 3: 高度化
+### Phase 3: Advanced
 
-外部連携やレポート機能を追加します。
+Add external integration and reporting features.
 
-**実装内容**:
+**Implementation:**
 
-1. **ブラックリスト参照API**
+1. **Blacklist reference API**
    ```ruby
    # GET /api/v1/bounced_addresses?email=test@example.com
    # => { "bounced": true, "reason": "user_unknown", "bounced_at": "..." }
    ```
 
-2. **バウンス統計・レポート**
-   - バウンス率の推移グラフ
-   - 理由別の集計
-   - ドメイン別のバウンス傾向
+2. **Bounce statistics/reports**
+   - Graph of bounce rate trends
+   - Aggregation by reason
+   - Bounce trends by domain
 
-3. **他システムへの通知**
-   - Webhook: バウンス検出時に外部システムへ通知
-   - Slack/Email通知: 閾値を超えた場合のアラート
+3. **Notification to other systems**
+   - Webhook: Notify external systems when a bounce is detected
+   - Slack/Email notification: Alert when threshold is exceeded
 
-4. **ホワイトリスト機能**
-   - 誤検知されたアドレスを除外
-   - 一時的にブラックリストを無効化
+4. **Whitelist feature**
+   - Exclude addresses that were falsely detected
+   - Temporarily disable blacklist
 
-**ゴール**: エンタープライズ用途でも使える高機能なバウンス管理基盤
+**Goal**: Highly functional bounce management platform suitable for enterprise use
 
-## 技術的考慮事項
+## Technical Considerations
 
-### Return-Path の設定
+### Return-Path Setting
 
-バウンスを確実に受信するため、以下の設定が必要です：
+To reliably receive bounces, the following settings are required:
 
-**現状の実装**:
+**Current implementation:**
 ```ruby
 mail.smtp_envelope_from(mail_queue.envelope_from)
 ```
 
-**バウンス管理対応**:
+**Bounce management support:**
 ```ruby
-# 環境変数で指定したバウンス受信用アドレスを使用
+# Use bounce receiving address specified by environment variable
 bounce_address = ENV['VERBENA_BOUNCE_ADDRESS'] || mail_queue.envelope_from
 mail.smtp_envelope_from(bounce_address)
 ```
 
-または VERP（Variable Envelope Return Path）方式：
+Or VERP (Variable Envelope Return Path) method:
 ```ruby
-# 配送ごとにユニークなReturn-Pathを生成
-# 例: bounce+12345@example.com (12345 = mail_queue.id)
+# Generate a unique Return-Path for each delivery
+# Example: bounce+12345@example.com (12345 = mail_queue.id)
 verp_address = "bounce+#{mail_queue.id}@example.com"
 mail.smtp_envelope_from(verp_address)
 ```
 
-### ブラックリストチェックのタイミング
+### Timing of Blacklist Check
 
-**推奨**: `DeliveryService#perform_one` 内でチェック
+**Recommended**: Check inside `DeliveryService#perform_one`
 
 ```ruby
 def perform_one(mail_queue)
-  # ブラックリストチェック
+  # Blacklist check
   if BouncedAddress.exists?(email: mail_queue.envelope_to)
     logger.info("Skipped: #{mail_queue.envelope_to} is blacklisted")
     mail_queue.delivery_responses.create!(
-      status: 550, # または独自コード 999
+      status: 550, # or custom code 999
       contents: 'Skipped: address is in bounce blacklist',
       responded_at: Time.current
     )
     return
   end
 
-  # ... 既存の配送ロジック
+  # ... existing delivery logic
 end
 ```
 
-この方式のメリット：
-- スキップしたレコードのログが残る
-- 柔軟な判定ロジック（例: 一時エラーは除外、恒久エラーのみブロック）
+Benefits of this approach:
+- Logs skipped records
+- Flexible logic (e.g., exclude temporary errors, block only permanent errors)
 
-### Sisimai の使い方（サンプル）
+### How to Use Sisimai (Sample)
 
 ```ruby
-# バウンスメール収集・解析サービス
+# Bounce mail collection/analysis service
 class BounceCollectorService
   def perform
-    # IMAP接続（例）
+    # IMAP connection (example)
     imap = Net::IMAP.new('imap.example.com', 993, true)
     imap.login('bounce@example.com', 'password')
     imap.select('INBOX')
 
-    # 未読メールを取得
+    # Get unread emails
     message_ids = imap.search(['UNSEEN'])
 
     message_ids.each do |msg_id|
-      # メール本文を取得
+      # Get email body
       msg = imap.fetch(msg_id, 'RFC822')[0].attr['RFC822']
 
-      # Sisimaiで解析
+      # Parse with Sisimai
       results = Sisimai.make(msg)
       next if results.nil? || results.empty?
 
       results.each do |bounce|
-        # 恒久的エラー（5xx）のみブラックリスト登録
+        # Register only permanent errors (5xx) to blacklist
         if bounce.deliverystatus.start_with?('5.')
           BouncedAddress.find_or_create_by(email: bounce.recipient) do |record|
             record.reason = bounce.reason
@@ -232,7 +232,7 @@ class BounceCollectorService
         end
       end
 
-      # 既読にする
+      # Mark as read
       imap.store(msg_id, '+FLAGS', [:Seen])
     end
 
@@ -242,27 +242,27 @@ class BounceCollectorService
 end
 ```
 
-## 運用フロー
+## Operational Flow
 
-### 日常運用（Phase 2 以降）
+### Daily Operation (Phase 2 and later)
 
-1. cronでバウンス収集バッチを定期実行（毎時）
-2. 恒久的エラーアドレスが自動的にブラックリスト登録される
-3. 配信時に自動的にスキップされる
-4. 管理画面でバウンス状況を確認・手動調整
+1. Run bounce collection batch periodically with cron (hourly)
+2. Permanent error addresses are automatically registered to the blacklist
+3. Automatically skipped at delivery time
+4. Check and manually adjust bounce status in the admin UI
 
-### トラブルシューティング
+### Troubleshooting
 
-- バウンスが正しく解析されない → Sisimai のログを確認、対応MTAを追加
-- 誤検知でブラックリスト登録された → 管理画面から削除、またはホワイトリスト機能で除外
-- バウンス率が急増 → レポートで原因特定（ドメイン・理由別集計）
+- Bounce not parsed correctly → Check Sisimai logs, add supported MTA
+- Falsely blacklisted → Remove from admin UI or exclude with whitelist feature
+- Sudden increase in bounce rate → Identify cause with reports (aggregate by domain/reason)
 
-## まとめ
+## Summary
 
-バウンス管理機能を段階的に実装することで、Verbenaは「SMTP配送管理」から「実質的な到達性管理」へと進化します。
+By implementing the bounce management feature in phases, Verbena will evolve from "SMTP delivery management" to "practical deliverability management."
 
-- **Phase 1**: 最小限の手動管理で即効性
-- **Phase 2**: 自動化で運用負荷削減
-- **Phase 3**: エンタープライズ用途への対応
+- **Phase 1**: Immediate effect with minimal manual management
+- **Phase 2**: Reduced operational burden through automation
+- **Phase 3**: Support for enterprise use
 
-単一アプリ構成を維持しつつ、疎結合な設計により将来の拡張性も確保します。
+While maintaining a single-app structure, loosely coupled design ensures future extensibility.

--- a/docs/DEVELOPMENT.ja.md
+++ b/docs/DEVELOPMENT.ja.md
@@ -1,0 +1,428 @@
+# Verbena 開発ガイド
+
+このドキュメントは Verbena の開発者向けの情報をまとめています。環境構築、テスト、アーキテクチャ設計、技術的な意思決定の背景などを記載しています。
+
+## 目次
+
+- [開発環境のセットアップ](#開発環境のセットアップ)
+- [I18n / ロケール](#i18n--ロケール)
+- [テスト](#テスト)
+- [アーキテクチャ](#アーキテクチャ)
+- [データベース設計](#データベース設計)
+- [トークン運用ルール](#トークン運用ルール)
+
+---
+
+## 開発環境のセットアップ
+
+### 前提条件
+
+- Docker と Docker Compose
+- Git
+
+
+### 初回セットアップ
+
+1. **リポジトリのクローン**
+
+```sh
+$ git clone https://github.com/hiroaki/Verbena.git
+$ cd Verbena
+$ git checkout develop
+```
+
+2. **環境変数の設定**
+
+※ コンテナ起動前に「データベース初期化用の環境変数」の設定が必要です。詳細は後述セクション（「データベース初期化用の環境変数」）を参照してください。
+
+環境変数は `.env` ファイル、`compose.yml`、各種 `compose.*.yml` などで管理できます。
+
+`.env` ファイルは必須ではありません。必要に応じて外部ファイルで管理したい場合のみ、以下のように作成・編集してください。
+
+```sh
+$ cp dot.env.sample .env
+```
+
+`.env` ファイルを使わず、`compose.yml` や各種 `compose.*.yml` に直接環境変数を記載している場合は `.env` は不要です。ご自身の運用に合わせて選択してください。
+
+3. **データベースの選択**
+
+Verbena の Docker Compose 構成は「共通 (compose.yml) + DB オーバーレイ」を組み合わせて利用します。使用したいデータベースに合わせて、以下のようにファイルを指定してください。
+
+```sh
+# MySQL / MariaDB
+$ docker compose -f compose.yml -f compose.mysql.yml up -d
+
+# PostgreSQL
+$ docker compose -f compose.yml -f compose.postgresql.yml up -d
+
+# SQLite (DB サービスは不要)
+$ docker compose -f compose.yml -f compose.sqlite.yml up -d
+```
+
+以降のコマンド例では MySQL オーバーレイ（`compose.mysql.yml`）を使用しています。PostgreSQL や SQLite を利用する場合は、適宜ファイル名を読み替えてください。
+
+4. **コンテナのビルドと起動**
+
+```sh
+$ docker compose -f compose.yml -f compose.mysql.yml build
+$ docker compose -f compose.yml -f compose.mysql.yml up -d
+```
+
+5. **データベースの初期化**
+
+```sh
+$ docker compose -f compose.yml -f compose.mysql.yml exec web rails db:migrate:reset
+```
+
+### データベース初期化用の環境変数
+
+初回起動時、データベースコンテナは `./initdb` 配下のスクリプトを自動実行してデータベースユーザーの権限を設定します。
+
+#### MySQL / MariaDB
+
+以下の環境変数が必要です（`.env` または `compose.mysql.yml` で指定）：
+
+| 変数名               | 説明 |
+|----------------------|------|
+| `MYSQL_ROOT_PASSWORD`| MySQL rootユーザーのパスワード。初期化スクリプト用。必須。 |
+| `MYSQL_USER`         | アプリ用DBユーザー名。必須。 |
+| `MYSQL_PASSWORD`     | アプリ用DBユーザーパスワード。必須。 |
+| `DATABASE_NAME`      | データベース名のベース。既定値: `verbena` |
+
+`.env` で `DATABASE_NAME` を指定すると、その値をベース名として開発用 DB を `${DATABASE_NAME}_development` という規約で自動作成します。
+
+#### PostgreSQL
+
+以下の環境変数を利用します（未設定時は表のデフォルト値を使用）：
+
+| 変数名 | 説明 |
+|--------|------|
+| `POSTGRES_USER` | PostgreSQL スーパーユーザー名。既定: `postgres` |
+| `POSTGRES_PASSWORD` | 上記スーパーユーザーのパスワード。既定: `postgres` |
+| `VERBENA_DATABASE_USER` | Rails アプリ用の DB ユーザー名。既定: `POSTGRES_USER` と同じ |
+| `VERBENA_DATABASE_PASSWORD` | 上記アプリ用ユーザーのパスワード。既定: `POSTGRES_PASSWORD` と同じ |
+| `DATABASE_NAME` | データベース名のベース。既定値: `verbena` |
+
+特に指定しない場合、アプリケーションユーザーと PostgreSQL スーパーユーザーは同じ資格情報になりますが、セキュリティ要件に応じて別々の値を設定できます。
+
+#### SQLite
+
+SQLite はファイルベースのため、DB サーバ用の環境変数は不要です。`storage/` ディレクトリに自動的にファイルが作成されます。
+
+#### 注意事項
+
+- ボリュームに既存のデータがある場合は初期化スクリプトが実行されません
+- 完全に初期状態へ戻す場合は「データベースの完全リセット」セクションを参照してください
+
+### データベースの完全リセット
+
+開発中にデータベースを完全に初期状態に戻したい場合はボリュームを削除し、再作成してください：
+
+1. **コンテナを停止してボリュームを削除**
+
+```sh
+$ docker compose -f compose.yml -f compose.mysql.yml down -v
+```
+
+2. **コンテナを再起動**
+
+```sh
+$ docker compose -f compose.yml -f compose.mysql.yml up -d
+```
+
+3. **データベースを再作成**
+
+```sh
+$ docker compose -f compose.yml -f compose.mysql.yml exec web rails db:migrate:reset
+```
+
+---
+
+## I18n / ロケール
+
+Verbena は日本語 (ja) / 英語 (en) の 2 言語に対応します。既定は英語です。
+
+- 既定ロケール: `en`
+- フォールバック: `ja -> en`
+- 設定場所: `config/application.rb`
+- ロケールファイル: `config/locales/*.yml`
+- 標準翻訳: `rails-i18n` gem を利用
+
+### 追加・更新の方針
+
+- 画面文言は `t("...")` を利用し、`config/locales/en.yml` と `config/locales/ja.yml` の両方にキーを追加します。
+- モデル名/属性名/エラーメッセージは `activerecord.*` 配下に整理します。
+- API メッセージは英語固定の方針です。
+
+---
+
+## テスト
+
+### テストの実行
+
+テストは RSpec を利用しています：
+
+```sh
+# 全テストを実行
+$ docker compose -f compose.yml -f compose.mysql.yml exec web bundle exec rspec
+
+# 特定ファイルだけ実行
+$ docker compose -f compose.yml -f compose.mysql.yml exec web bundle exec rspec spec/tasks/verbena/mail_queues_rake_spec.rb
+
+# 特定の行だけ実行
+$ docker compose -f compose.yml -f compose.mysql.yml exec web bundle exec rspec spec/models/mail_queue_spec.rb:42
+```
+
+### カバレッジレポート
+
+テストを実行すると `coverage` ディレクトリにカバレッジレポートが出力されます：
+
+```sh
+$ open coverage/index.html
+```
+
+---
+
+## アーキテクチャ
+
+### システムの責務範囲
+
+#### 配送のスコープ
+
+Verbena は **SMTP 配送先サーバへの引き渡しまで** を担当します。
+
+- **担当する範囲**: アプリケーションから配送先SMTPサーバへのメール配信が成功したこと（SMTP応答 `250 OK` の受信）
+- **担当しない範囲**:
+  - リレー先サーバでの配送失敗（バウンス）
+  - スパムフィルタによるブロック
+  - 最終的な受信箱への到達
+  - ユーザーによる開封・閲覧
+
+この責務範囲の定義は、SMTP プロトコルの技術的特性に基づいています：
+
+- SMTP の「250 OK」応答は、そのサーバがメールを受理したことのみを意味します
+- その後のリレーや最終配送での失敗は、即時には検知できません
+- 後続のバウンスは通常「バウンスメール（DSN）」として送信元に返送されます
+
+SMTP プロトコルの仕様上、配送先サーバが `250 OK` を返した時点で「受理した」ことのみが確認できます。その後のリレーや最終的な受信箱への到達、バウンス発生については、配送元から即時に把握する手段はありません。
+
+また、バウンス（配信不能通知）は配送先サーバが後から送信元に返す仕組みであり、非同期かつ必ずしも返送されるとは限りません。そのため、リアルタイムな到達確認や再送制御は SMTP の標準的な仕組みでは実現されていません。
+
+### 設計原則
+
+#### 1. 並行処理の安全性
+
+- **SolidQueue** を採用し、標準的な非同期ジョブ基盤上でスケーラブルな並行処理を実現
+- `DeliveryJob` によるジョブ単位での安定した配送実行
+- ジョブのリトライ機構を利用した堅牢なエラーハンドリング
+
+#### 2. 追跡可能性
+
+- すべての配送試行を `DeliveryResponse` に記録
+- 構造化ログによる配送プロセスの可視化
+- `Message-ID` によるメール追跡
+
+#### 3. 柔軟な配送制御
+
+- タイマーベース配送（遅延配信）：`ScheduledDeliveryJob` によるポーリングとエンキュー
+- 4xxステータスの再送管理：エラー時の再送処理による自動リカバリ
+- バッチサイズ・並行数の調整可能
+
+#### 4. 運用容易性
+
+- Docker環境での完結した開発・テスト
+- Rakeタスクによる日常運用
+- 設定の環境変数管理
+
+### システム構成
+
+#### コアモデル
+
+Verbena のコアモデルは、メール配送処理の各段階を明確に分離して管理します。
+
+- **EmlSource**: 受信した EML ファイル（生メールデータ）を保存します。1通の EML につき1レコード。添付ファイルやヘッダ情報も含め、元のメール内容をそのまま保持します。
+
+- **MailQueue**: 配送対象ごと（受信者ごと）に配送キューを生成します。1つの EML から複数の MailQueue が作成されることもあります（例: 複数受信者への同報送信）。配送予定時刻やステータス、リトライ回数などの管理も行います。
+
+- **DeliveryResponse**: 各配送試行の結果を記録します。SMTP サーバへの配送ごとに1レコードが作成され、応答内容（例: 250 OK やエラーコード）、配送日時、リトライ情報などを保持します。
+
+モデル間の関係は以下の通りです：
+
+```
+EmlSource (生EML保存)
+  └─<1対多>─> MailQueue (配送キュー、受信者ごと)
+      └─<1対多>─> DeliveryResponse (配送結果)
+```
+
+この構造により、1通のメール（EML）から複数受信者への個別配送、各配送のリトライや結果追跡が柔軟に行えます。
+
+#### 配送フロー
+
+Verbena の配送フローは、EML ファイルの受信から配送完了・後処理まで、以下の段階で構成されています。
+
+1. **Ingest（取り込み）**
+  - ユーザーや外部システムから EML ファイル（生メールデータ）がアップロードまたは投入されます。
+  - `MailQueuesService` が EML を解析し、宛先ごとに `MailQueue` レコードを生成します。
+  - これにより、1通のメールから複数受信者への個別配送が可能になります。
+
+2. **Scheduling（配送スケジューリング）**
+  - 各 `MailQueue` には配送予定時刻や即時配送フラグが設定されます。
+  - 即時配送の場合は、`MailQueue` 作成直後に `DeliveryJob` がエンキューされます。
+  - 予約配送の場合は、`ScheduledDeliveryJob` が定期的に実行され、配送予定時刻に達したキューを検知して `DeliveryJob` をエンキューします。
+  - これにより、遅延配信やバッチ配送など柔軟なスケジューリングが可能です。
+
+3. **Deliver（配送実行）**
+  - `DeliveryJob` がキューごとに起動し、`DeliveryService` を通じて SMTP サーバへの配送処理を行います。
+  - 配送の成否や SMTP 応答内容は `DeliveryResponse` に記録されます。
+  - エラー発生時はリトライ制御も行われ、再配送が必要な場合は再度ジョブがエンキューされます。
+
+4. **Cleanup（後処理・クリーンアップ）**
+  - 配送が完了した `MailQueue` や、参照されなくなった `EmlSource` の削除（クリーンアップ）は、ユーザーが任意のタイミングで Rake タスク（例: `verbena:cleanup:weekly` など）を実行することで行います。
+  - 定期的な自動実行は標準では設定されていません。必要に応じて cron 等でスケジューリングしてください。
+
+
+この一連のフローにより、EML の受信から多宛先への個別配送、配送結果の記録までを自動化し、データ保持・削除の運用は利用者の裁量に委ねています。
+
+#### メールデータ入力の仕組み
+
+Verbena では、配送対象となるメールデータ（EML形式）は `eml_sources` テーブルに保存されます。それと同時に EMLのヘッダ `To:` `Cc:` `Bcc:` に記載された各宛先ごとに、配送キューとして `mail_queues` テーブルのレコードが作成されます（重複は除外）。
+
+##### 入力方法
+
+- Rakeタスク経由: EMLファイルのパスを指定して `verbena:mail_queues:add` を実行
+- Web API経由: EMLデータをPOST（`Authorization`ヘッダにトークン必須）
+
+いずれの場合も、EMLの宛先ヘッダに基づき複数の `mail_queues` レコードが生成されます。
+
+例：
+
+```sh
+Date: Tue, 1 Jul 2003 10:52:37 +0200
+From: me@example.com
+To: you@example.com
+Cc: ichiro@example.com, jirou@example.com
+Bcc: saburo@example.com
+Subject: ...
+Content-Type: text/plain; charset="UTF-8"
+
+こんにちは。
+```
+
+この場合、4件の `mail_queues` レコードが作成されます。
+
+各レコードの違いは、実際の送信先となるメールアドレスが格納される `envelope_to` カラムのみです。配送処理は `mail_queues` の各レコード単位で行われ、EMLのヘッダ上の複数宛先情報は関係なく、`envelope_to` の宛先にのみ送信されます。
+
+また、EMLのヘッダ `Date:` の値は「配送予約時刻」として `mail_queues` テーブルの `timer_at` カラムに格納されます。`Date:` が省略された場合は、`timer_at` には現在時刻が設定されます。
+
+
+### 将来の拡張計画
+
+#### バウンス管理機能（次期マイルストーン）
+
+配送後のバウンスを管理することで、実質的な到達性を向上させます。
+詳細は [BOUNCE_MANAGEMENT.ja.md](BOUNCE_MANAGEMENT.ja.md) を参照してください。
+
+#### 想定される拡張機能
+
+- 配信速度制御（レート制限）
+- 宛先ドメインごとの同時接続数制限
+- DKIM署名サポート
+- 配信統計ダッシュボード
+- Webhook通知
+
+---
+
+## データベース設計
+
+### 対応データベース
+
+Verbena は複数のデータベースシステムをサポートします：
+
+| Database | Version | Status |
+|----------|---------|--------|
+| MySQL    | 8.0+    | ✅ Supported |
+| MariaDB  | 10.6+   | ✅ Supported |
+| PostgreSQL | 13+   | ✅ Supported |
+| SQLite   | 3.x     | ✅ Supported |
+
+### マイグレーションの互換性
+
+すべてのマイグレーション（`db/migrate/`）は、以下の原則に従い、複数のデータベースで動作するように設計されています：
+
+- **MySQL 専用オプション（`after:`、`charset:`、`collation:`）は使用しない**: MySQL 固有の `after:` などでカラム並び順を制御・前提とせず、実際の並び順は各データベース実装に依存するものとして、ポータブルな Rails マイグレーション構文を採用
+- **型固有のオプションはアダプタ非依存**: `:text` 型に対する MySQL 固有のサイズ指定オプション（`limit:` など）のように、DB ごとに挙動が異なる指定は使わず、すべての DB で解釈可能なプレーンな型指定のみを使用
+- **SQL の直接記述を避ける**: `execute()` 句で vendor-specific SQL を使わないよう注意
+
+### データベースの可搬性に関する注意
+
+本プロジェクトの `db/schema.rb` は MySQL 環境を基準（リファレンス）として生成されています。そのため `charset: "utf8mb4"` などの MySQL 固有オプションが含まれています。
+
+PostgreSQL や SQLite などの他データベースを使用する場合、`bin/rails db:schema:load`（または `bin/setup` 内の `db:prepare`）を実行するとこれらの固有オプションが原因でエラーになる可能性があります。
+
+**MySQL 以外のデータベースで環境構築を行う場合は、`db:schema:load` を介さない以下のコマンド（マイグレーションからの構築）を使用してください：**
+
+```sh
+# PostgreSQL / SQLite の場合
+$ bin/rails db:create
+$ bin/rails db:migrate
+```
+
+### タイムゾーン方針 (UTC)
+
+Verbena は一貫して UTC で動作するように設計されています：
+
+- **Rails アプリケーション**: 常に UTC で動作（`config.time_zone = 'UTC'`）
+- **データベース OS**: タイムゾーンを UTC（`TZ=UTC`）に固定
+- **MySQL/MariaDB**: `config/database.yml` で `init_command: "SET time_zone = '+00:00'"` を指定し、セッションのタイムゾーンを UTC に固定
+- **PostgreSQL**: `config/database.yml` で `variables: { timezone: 'UTC' }` を指定し、セッションタイムゾーンを UTC に固定
+- **SQLite**: セッション／データベースのタイムゾーン設定はなし。日時は Rails 側で UTC として生成・管理
+
+#### プログラミングガイドライン
+
+- DB内の `NOW()` や `CURRENT_TIMESTAMP` などのタイムゾーンが影響する関数は使わず、Rails で生成した日時値をバインドして利用してください
+- 日時は常に UTC として扱い、表示時のみユーザーのタイムゾーンに変換します
+
+### EML データの保存方針
+
+EML (Raw email format) は `eml_sources.eml` カラムに保存されます。
+
+#### 現在の方針（互換性優先）
+
+- データベースに保存する EML は plain `:text` 型を使用し、すべてのデータベースで互換性を確保しています
+- MySQL の `TEXT` 型は約 64 KiB、PostgreSQL と SQLite の `text` は事実上無制限です
+- 添付ファイルがない、または小さいメール（通常のビジネスメール）であれば、この制限内で対応可能です
+
+#### 将来の拡張計画（オブジェクトストレージ対応予定）
+
+- より大きな EML ファイル（大きな添付ファイル付き）をサポートするために、オブジェクトストレージの利用を検討しています
+- その際は、EML 本体をストレージに保存し、DB にはメタデータと小さなプレビューのみを保持します
+
+## トークン運用ルール
+
+Verbena のメールデータ入力（Rake/Web API）には Bearer トークン認証が必要です。トークン管理・運用上の注意点は以下の通りです。
+
+- トークンの発行・更新は管理者のみが行います。利用者は配布された `key` のみ使用し、作成や更新はできません。
+- 発行時はモデルのファクトリメソッド `Token.create_unique!` を使用してください。
+- `key` の値は機密情報です。対象利用者以外に見られないよう保護してください。
+- `label` は利用者の目印としてユニークな値を設定します。
+- 有効期限は `expires_at` に設定し、その時刻まで有効です（必須）。
+- 無効化は物理削除ではなく `revoked_at` をセットすることで行ってください（監査のため）。
+- 発行後の `key` の更新は禁止されています（UNIQUE制約違反時に他人のkeyの存在が推測できるため、セキュリティ上の理由です）。変更が必要な場合は既存トークンを `revoke!` して無効化し、新しいトークンを作成してください。
+- 期限切れトークンの一括無効化は Rake タスク `verbena:tokens:revoke_expired` を利用してください。
+
+作成例：
+
+```ruby
+Token.create_unique!(label: "hoge", key: "user-secret", expires_at: 1.year.from_now)
+```
+
+期限切れトークンの無効化：
+
+```sh
+# ドライラン（何件無効化されるかを確認）
+$ bundle exec rake verbena:tokens:revoke_expired[dry]
+
+# 実行（expires_at を過ぎ、まだ revoked されていないトークンを revoked にする）
+$ bundle exec rake verbena:tokens:revoke_expired
+```

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,29 +1,30 @@
-# Verbena 開発ガイド
 
-このドキュメントは Verbena の開発者向けの情報をまとめています。環境構築、テスト、アーキテクチャ設計、技術的な意思決定の背景などを記載しています。
+# Verbena Development Guide
 
-## 目次
+This document provides information for Verbena developers, including environment setup, testing, architecture design, and the background of technical decisions.
 
-- [開発環境のセットアップ](#開発環境のセットアップ)
-- [I18n / ロケール](#i18n--ロケール)
-- [テスト](#テスト)
-- [アーキテクチャ](#アーキテクチャ)
-- [データベース設計](#データベース設計)
-- [トークン運用ルール](#トークン運用ルール)
+## Table of Contents
+
+- [Development Environment Setup](#development-environment-setup)
+- [I18n / Locale](#i18n--locale)
+- [Testing](#testing)
+- [Architecture](#architecture)
+- [Database Design](#database-design)
+- [Token Operation Rules](#token-operation-rules)
 
 ---
 
-## 開発環境のセットアップ
+## Development Environment Setup
 
-### 前提条件
+### Prerequisites
 
-- Docker と Docker Compose
+- Docker and Docker Compose
 - Git
 
 
-### 初回セットアップ
+### Initial Setup
 
-1. **リポジトリのクローン**
+1. **Clone the repository**
 
 ```sh
 $ git clone https://github.com/hiroaki/Verbena.git
@@ -31,23 +32,23 @@ $ cd Verbena
 $ git checkout develop
 ```
 
-2. **環境変数の設定**
+2. **Set environment variables**
 
-※ コンテナ起動前に「データベース初期化用の環境変数」の設定が必要です。詳細は後述セクション（「データベース初期化用の環境変数」）を参照してください。
+*Before starting containers, you must set the "database initialization environment variables". See the later section ("Database Initialization Environment Variables") for details.*
 
-環境変数は `.env` ファイル、`compose.yml`、各種 `compose.*.yml` などで管理できます。
+Environment variables can be managed in `.env` files, `compose.yml`, and various `compose.*.yml` files.
 
-`.env` ファイルは必須ではありません。必要に応じて外部ファイルで管理したい場合のみ、以下のように作成・編集してください。
+The `.env` file is not required. Create or edit it only if you want to manage variables in an external file as needed.
 
 ```sh
 $ cp dot.env.sample .env
 ```
 
-`.env` ファイルを使わず、`compose.yml` や各種 `compose.*.yml` に直接環境変数を記載している場合は `.env` は不要です。ご自身の運用に合わせて選択してください。
+If you specify environment variables directly in `compose.yml` or `compose.*.yml`, the `.env` file is unnecessary. Choose according to your operational needs.
 
-3. **データベースの選択**
+3. **Select the database**
 
-Verbena の Docker Compose 構成は「共通 (compose.yml) + DB オーバーレイ」を組み合わせて利用します。使用したいデータベースに合わせて、以下のようにファイルを指定してください。
+Verbena's Docker Compose setup uses a combination of "common (compose.yml) + DB overlay". Specify the files according to the database you want to use:
 
 ```sh
 # MySQL / MariaDB
@@ -56,82 +57,82 @@ $ docker compose -f compose.yml -f compose.mysql.yml up -d
 # PostgreSQL
 $ docker compose -f compose.yml -f compose.postgresql.yml up -d
 
-# SQLite (DB サービスは不要)
+# SQLite (no DB service required)
 $ docker compose -f compose.yml -f compose.sqlite.yml up -d
 ```
 
-以降のコマンド例では MySQL オーバーレイ（`compose.mysql.yml`）を使用しています。PostgreSQL や SQLite を利用する場合は、適宜ファイル名を読み替えてください。
+The following command examples use the MySQL overlay (`compose.mysql.yml`). If you use PostgreSQL or SQLite, replace the file names as appropriate.
 
-4. **コンテナのビルドと起動**
+4. **Build and start containers**
 
 ```sh
 $ docker compose -f compose.yml -f compose.mysql.yml build
 $ docker compose -f compose.yml -f compose.mysql.yml up -d
 ```
 
-5. **データベースの初期化**
+5. **Initialize the database**
 
 ```sh
 $ docker compose -f compose.yml -f compose.mysql.yml exec web rails db:migrate:reset
 ```
 
-### データベース初期化用の環境変数
+### Database Initialization Environment Variables
 
-初回起動時、データベースコンテナは `./initdb` 配下のスクリプトを自動実行してデータベースユーザーの権限を設定します。
+On first startup, the database container automatically runs scripts under `./initdb` to set database user privileges.
 
 #### MySQL / MariaDB
 
-以下の環境変数が必要です（`.env` または `compose.mysql.yml` で指定）：
+The following environment variables are required (specify in `.env` or `compose.mysql.yml`):
 
-| 変数名               | 説明 |
-|----------------------|------|
-| `MYSQL_ROOT_PASSWORD`| MySQL rootユーザーのパスワード。初期化スクリプト用。必須。 |
-| `MYSQL_USER`         | アプリ用DBユーザー名。必須。 |
-| `MYSQL_PASSWORD`     | アプリ用DBユーザーパスワード。必須。 |
-| `DATABASE_NAME`      | データベース名のベース。既定値: `verbena` |
+| Variable Name         | Description |
+|----------------------|-------------|
+| `MYSQL_ROOT_PASSWORD`| MySQL root user password. Required for initialization scripts. Required. |
+| `MYSQL_USER`         | DB username for the app. Required. |
+| `MYSQL_PASSWORD`     | DB user password for the app. Required. |
+| `DATABASE_NAME`      | Base name for the database. Default: `verbena` |
 
-`.env` で `DATABASE_NAME` を指定すると、その値をベース名として開発用 DB を `${DATABASE_NAME}_development` という規約で自動作成します。
+If you specify `DATABASE_NAME` in `.env`, the development DB will be automatically created as `${DATABASE_NAME}_development`.
 
 #### PostgreSQL
 
-以下の環境変数を利用します（未設定時は表のデフォルト値を使用）：
+The following environment variables are used (if not set, the table defaults are used):
 
-| 変数名 | 説明 |
-|--------|------|
-| `POSTGRES_USER` | PostgreSQL スーパーユーザー名。既定: `postgres` |
-| `POSTGRES_PASSWORD` | 上記スーパーユーザーのパスワード。既定: `postgres` |
-| `VERBENA_DATABASE_USER` | Rails アプリ用の DB ユーザー名。既定: `POSTGRES_USER` と同じ |
-| `VERBENA_DATABASE_PASSWORD` | 上記アプリ用ユーザーのパスワード。既定: `POSTGRES_PASSWORD` と同じ |
-| `DATABASE_NAME` | データベース名のベース。既定値: `verbena` |
+| Variable Name | Description |
+|---------------|-------------|
+| `POSTGRES_USER` | PostgreSQL superuser name. Default: `postgres` |
+| `POSTGRES_PASSWORD` | Password for the above superuser. Default: `postgres` |
+| `VERBENA_DATABASE_USER` | DB username for the Rails app. Default: same as `POSTGRES_USER` |
+| `VERBENA_DATABASE_PASSWORD` | Password for the above app user. Default: same as `POSTGRES_PASSWORD` |
+| `DATABASE_NAME` | Base name for the database. Default: `verbena` |
 
-特に指定しない場合、アプリケーションユーザーと PostgreSQL スーパーユーザーは同じ資格情報になりますが、セキュリティ要件に応じて別々の値を設定できます。
+If not specified, the application user and PostgreSQL superuser will use the same credentials, but you can set them separately for security requirements.
 
 #### SQLite
 
-SQLite はファイルベースのため、DB サーバ用の環境変数は不要です。`storage/` ディレクトリに自動的にファイルが作成されます。
+SQLite is file-based, so no DB server environment variables are needed. Files are automatically created in the `storage/` directory.
 
-#### 注意事項
+#### Notes
 
-- ボリュームに既存のデータがある場合は初期化スクリプトが実行されません
-- 完全に初期状態へ戻す場合は「データベースの完全リセット」セクションを参照してください
+- If there is existing data in the volume, the initialization script will not run.
+- To return to a completely initial state, see the "Full Database Reset" section.
 
-### データベースの完全リセット
+### Full Database Reset
 
-開発中にデータベースを完全に初期状態に戻したい場合はボリュームを削除し、再作成してください：
+If you want to return the database to a completely initial state during development, delete and recreate the volume:
 
-1. **コンテナを停止してボリュームを削除**
+1. **Stop containers and delete the volume**
 
 ```sh
 $ docker compose -f compose.yml -f compose.mysql.yml down -v
 ```
 
-2. **コンテナを再起動**
+2. **Restart containers**
 
 ```sh
 $ docker compose -f compose.yml -f compose.mysql.yml up -d
 ```
 
-3. **データベースを再作成**
+3. **Recreate the database**
 
 ```sh
 $ docker compose -f compose.yml -f compose.mysql.yml exec web rails db:migrate:reset
@@ -139,44 +140,44 @@ $ docker compose -f compose.yml -f compose.mysql.yml exec web rails db:migrate:r
 
 ---
 
-## I18n / ロケール
+## I18n / Locale
 
-Verbena は日本語 (ja) / 英語 (en) の 2 言語に対応します。既定は英語です。
+Verbena supports two languages: Japanese (ja) and English (en). The default is English.
 
-- 既定ロケール: `en`
-- フォールバック: `ja -> en`
-- 設定場所: `config/application.rb`
-- ロケールファイル: `config/locales/*.yml`
-- 標準翻訳: `rails-i18n` gem を利用
+- Default locale: `en`
+- Fallback: `ja -> en`
+- Configuration: `config/application.rb`
+- Locale files: `config/locales/*.yml`
+- Standard translations: Uses the `rails-i18n` gem
 
-### 追加・更新の方針
+### Addition/Update Policy
 
-- 画面文言は `t("...")` を利用し、`config/locales/en.yml` と `config/locales/ja.yml` の両方にキーを追加します。
-- モデル名/属性名/エラーメッセージは `activerecord.*` 配下に整理します。
-- API メッセージは英語固定の方針です。
+- UI strings should use `t("...")`, and keys should be added to both `config/locales/en.yml` and `config/locales/ja.yml`.
+- Model names/attribute names/error messages are organized under `activerecord.*`.
+- API messages are fixed in English.
 
 ---
 
-## テスト
+## Testing
 
-### テストの実行
+### Running Tests
 
-テストは RSpec を利用しています：
+Tests use RSpec:
 
 ```sh
-# 全テストを実行
+# Run all tests
 $ docker compose -f compose.yml -f compose.mysql.yml exec web bundle exec rspec
 
-# 特定ファイルだけ実行
+# Run only a specific file
 $ docker compose -f compose.yml -f compose.mysql.yml exec web bundle exec rspec spec/tasks/verbena/mail_queues_rake_spec.rb
 
-# 特定の行だけ実行
+# Run only a specific line
 $ docker compose -f compose.yml -f compose.mysql.yml exec web bundle exec rspec spec/models/mail_queue_spec.rb:42
 ```
 
-### カバレッジレポート
+### Coverage Report
 
-テストを実行すると `coverage` ディレクトリにカバレッジレポートが出力されます：
+When you run tests, a coverage report is output to the `coverage` directory:
 
 ```sh
 $ open coverage/index.html
@@ -184,118 +185,118 @@ $ open coverage/index.html
 
 ---
 
-## アーキテクチャ
+## Architecture
 
-### システムの責務範囲
+### System Responsibility Scope
 
-#### 配送のスコープ
+#### Delivery Scope
 
-Verbena は **SMTP 配送先サーバへの引き渡しまで** を担当します。
+Verbena is responsible **up to handing off to the destination SMTP server**.
 
-- **担当する範囲**: アプリケーションから配送先SMTPサーバへのメール配信が成功したこと（SMTP応答 `250 OK` の受信）
-- **担当しない範囲**:
-  - リレー先サーバでの配送失敗（バウンス）
-  - スパムフィルタによるブロック
-  - 最終的な受信箱への到達
-  - ユーザーによる開封・閲覧
+- **In scope**: Successful delivery from the application to the destination SMTP server (receiving SMTP response `250 OK`)
+- **Out of scope**:
+  - Delivery failure at relay servers (bounces)
+  - Blocking by spam filters
+  - Final inbox delivery
+  - User opening/reading
 
-この責務範囲の定義は、SMTP プロトコルの技術的特性に基づいています：
+This definition of responsibility is based on the technical characteristics of the SMTP protocol:
 
-- SMTP の「250 OK」応答は、そのサーバがメールを受理したことのみを意味します
-- その後のリレーや最終配送での失敗は、即時には検知できません
-- 後続のバウンスは通常「バウンスメール（DSN）」として送信元に返送されます
+- The SMTP "250 OK" response only means that the server has accepted the email
+- Failures in subsequent relays or final delivery cannot be detected immediately
+- Subsequent bounces are usually returned to the sender as "bounce emails (DSN)"
 
-SMTP プロトコルの仕様上、配送先サーバが `250 OK` を返した時点で「受理した」ことのみが確認できます。その後のリレーや最終的な受信箱への到達、バウンス発生については、配送元から即時に把握する手段はありません。
+According to the SMTP protocol specification, when the destination server returns `250 OK`, only "acceptance" is confirmed. There is no way for the sender to immediately know about subsequent relays, final inbox delivery, or bounces.
 
-また、バウンス（配信不能通知）は配送先サーバが後から送信元に返す仕組みであり、非同期かつ必ずしも返送されるとは限りません。そのため、リアルタイムな到達確認や再送制御は SMTP の標準的な仕組みでは実現されていません。
+Also, bounces (delivery failure notifications) are sent back to the sender by the destination server later, asynchronously, and not always guaranteed. Therefore, real-time delivery confirmation and retry control are not implemented in standard SMTP mechanisms.
 
-### 設計原則
+### Design Principles
 
-#### 1. 並行処理の安全性
+#### 1. Safe Concurrency
 
-- **SolidQueue** を採用し、標準的な非同期ジョブ基盤上でスケーラブルな並行処理を実現
-- `DeliveryJob` によるジョブ単位での安定した配送実行
-- ジョブのリトライ機構を利用した堅牢なエラーハンドリング
+- Uses **SolidQueue** to achieve scalable concurrency on a standard asynchronous job platform
+- Stable delivery execution per job via `DeliveryJob`
+- Robust error handling using job retry mechanisms
 
-#### 2. 追跡可能性
+#### 2. Traceability
 
-- すべての配送試行を `DeliveryResponse` に記録
-- 構造化ログによる配送プロセスの可視化
-- `Message-ID` によるメール追跡
+- All delivery attempts are recorded in `DeliveryResponse`
+- Delivery process is visualized with structured logs
+- Email tracking via `Message-ID`
 
-#### 3. 柔軟な配送制御
+#### 3. Flexible Delivery Control
 
-- タイマーベース配送（遅延配信）：`ScheduledDeliveryJob` によるポーリングとエンキュー
-- 4xxステータスの再送管理：エラー時の再送処理による自動リカバリ
-- バッチサイズ・並行数の調整可能
+- Timer-based delivery (delayed delivery): polling and enqueueing via `ScheduledDeliveryJob`
+- Retry management for 4xx statuses: automatic recovery via retry processing on errors
+- Adjustable batch size and concurrency
 
-#### 4. 運用容易性
+#### 4. Operational Ease
 
-- Docker環境での完結した開発・テスト
-- Rakeタスクによる日常運用
-- 設定の環境変数管理
+- Complete development and testing in Docker environment
+- Daily operations via Rake tasks
+- Environment variable management for configuration
 
-### システム構成
+### System Structure
 
-#### コアモデル
+#### Core Models
 
-Verbena のコアモデルは、メール配送処理の各段階を明確に分離して管理します。
+Verbena's core models clearly separate and manage each stage of the email delivery process.
 
-- **EmlSource**: 受信した EML ファイル（生メールデータ）を保存します。1通の EML につき1レコード。添付ファイルやヘッダ情報も含め、元のメール内容をそのまま保持します。
+- **EmlSource**: Stores received EML files (raw email data). One record per EML. Retains the original email content, including attachments and header information.
 
-- **MailQueue**: 配送対象ごと（受信者ごと）に配送キューを生成します。1つの EML から複数の MailQueue が作成されることもあります（例: 複数受信者への同報送信）。配送予定時刻やステータス、リトライ回数などの管理も行います。
+- **MailQueue**: Generates a delivery queue for each recipient. Multiple MailQueues may be created from one EML (e.g., broadcast to multiple recipients). Also manages scheduled delivery time, status, retry count, etc.
 
-- **DeliveryResponse**: 各配送試行の結果を記録します。SMTP サーバへの配送ごとに1レコードが作成され、応答内容（例: 250 OK やエラーコード）、配送日時、リトライ情報などを保持します。
+- **DeliveryResponse**: Records the result of each delivery attempt. One record is created for each delivery to an SMTP server, storing response content (e.g., 250 OK or error code), delivery time, retry info, etc.
 
-モデル間の関係は以下の通りです：
+The relationships between models are as follows:
 
 ```
-EmlSource (生EML保存)
-  └─<1対多>─> MailQueue (配送キュー、受信者ごと)
-      └─<1対多>─> DeliveryResponse (配送結果)
+EmlSource (raw EML storage)
+  └─<1-to-many>─> MailQueue (delivery queue, per recipient)
+      └─<1-to-many>─> DeliveryResponse (delivery result)
 ```
 
-この構造により、1通のメール（EML）から複数受信者への個別配送、各配送のリトライや結果追跡が柔軟に行えます。
+This structure allows flexible individual delivery to multiple recipients from a single email (EML), as well as retry and result tracking for each delivery.
 
-#### 配送フロー
+#### Delivery Flow
 
-Verbena の配送フローは、EML ファイルの受信から配送完了・後処理まで、以下の段階で構成されています。
+Verbena's delivery flow consists of the following stages, from receiving the EML file to delivery completion and post-processing.
 
-1. **Ingest（取り込み）**
-  - ユーザーや外部システムから EML ファイル（生メールデータ）がアップロードまたは投入されます。
-  - `MailQueuesService` が EML を解析し、宛先ごとに `MailQueue` レコードを生成します。
-  - これにより、1通のメールから複数受信者への個別配送が可能になります。
+1. **Ingest**
+  - EML files (raw email data) are uploaded or submitted by users or external systems.
+  - `MailQueuesService` parses the EML and generates `MailQueue` records for each recipient.
+  - This enables individual delivery to multiple recipients from a single email.
 
-2. **Scheduling（配送スケジューリング）**
-  - 各 `MailQueue` には配送予定時刻や即時配送フラグが設定されます。
-  - 即時配送の場合は、`MailQueue` 作成直後に `DeliveryJob` がエンキューされます。
-  - 予約配送の場合は、`ScheduledDeliveryJob` が定期的に実行され、配送予定時刻に達したキューを検知して `DeliveryJob` をエンキューします。
-  - これにより、遅延配信やバッチ配送など柔軟なスケジューリングが可能です。
+2. **Scheduling**
+  - Each `MailQueue` is assigned a scheduled delivery time or immediate delivery flag.
+  - For immediate delivery, `DeliveryJob` is enqueued immediately after `MailQueue` creation.
+  - For scheduled delivery, `ScheduledDeliveryJob` runs periodically, detects queues whose scheduled time has arrived, and enqueues `DeliveryJob`.
+  - This enables flexible scheduling such as delayed or batch delivery.
 
-3. **Deliver（配送実行）**
-  - `DeliveryJob` がキューごとに起動し、`DeliveryService` を通じて SMTP サーバへの配送処理を行います。
-  - 配送の成否や SMTP 応答内容は `DeliveryResponse` に記録されます。
-  - エラー発生時はリトライ制御も行われ、再配送が必要な場合は再度ジョブがエンキューされます。
+3. **Deliver**
+  - `DeliveryJob` is started for each queue and performs delivery to the SMTP server via `DeliveryService`.
+  - The success/failure and SMTP response are recorded in `DeliveryResponse`.
+  - If an error occurs, retry control is performed, and if redelivery is needed, the job is enqueued again.
 
-4. **Cleanup（後処理・クリーンアップ）**
-  - 配送が完了した `MailQueue` や、参照されなくなった `EmlSource` の削除（クリーンアップ）は、ユーザーが任意のタイミングで Rake タスク（例: `verbena:cleanup:weekly` など）を実行することで行います。
-  - 定期的な自動実行は標準では設定されていません。必要に応じて cron 等でスケジューリングしてください。
+4. **Cleanup**
+  - Cleanup (deletion) of completed `MailQueue` and unreferenced `EmlSource` is performed by running Rake tasks (e.g., `verbena:cleanup:weekly`) at any time by the user.
+  - Periodic automatic execution is not set by default. Schedule with cron, etc., as needed.
 
 
-この一連のフローにより、EML の受信から多宛先への個別配送、配送結果の記録までを自動化し、データ保持・削除の運用は利用者の裁量に委ねています。
+This flow automates everything from EML reception to individual delivery to multiple recipients and recording delivery results, while leaving data retention/deletion operations to the user's discretion.
 
-#### メールデータ入力の仕組み
+#### Email Data Input Mechanism
 
-Verbena では、配送対象となるメールデータ（EML形式）は `eml_sources` テーブルに保存されます。それと同時に EMLのヘッダ `To:` `Cc:` `Bcc:` に記載された各宛先ごとに、配送キューとして `mail_queues` テーブルのレコードが作成されます（重複は除外）。
+In Verbena, email data to be delivered (EML format) is stored in the `eml_sources` table. At the same time, for each recipient listed in the EML headers `To:`, `Cc:`, and `Bcc:`, a record is created in the `mail_queues` table as a delivery queue (duplicates are excluded).
 
-##### 入力方法
+##### Input Methods
 
-- Rakeタスク経由: EMLファイルのパスを指定して `verbena:mail_queues:add` を実行
-- Web API経由: EMLデータをPOST（`Authorization`ヘッダにトークン必須）
+- Via Rake task: Specify the EML file path and run `verbena:mail_queues:add`
+- Via Web API: POST EML data (token required in `Authorization` header)
 
-いずれの場合も、EMLの宛先ヘッダに基づき複数の `mail_queues` レコードが生成されます。
+In either case, multiple `mail_queues` records are generated based on the EML recipient headers.
 
-例：
+Example:
 
 ```sh
 Date: Tue, 1 Jul 2003 10:52:37 +0200
@@ -306,123 +307,123 @@ Bcc: saburo@example.com
 Subject: ...
 Content-Type: text/plain; charset="UTF-8"
 
-こんにちは。
+Hello.
 ```
 
-この場合、4件の `mail_queues` レコードが作成されます。
+In this case, four `mail_queues` records are created.
 
-各レコードの違いは、実際の送信先となるメールアドレスが格納される `envelope_to` カラムのみです。配送処理は `mail_queues` の各レコード単位で行われ、EMLのヘッダ上の複数宛先情報は関係なく、`envelope_to` の宛先にのみ送信されます。
+The only difference between each record is the `envelope_to` column, which stores the actual recipient email address. Delivery processing is performed per record in `mail_queues`, and only the address in `envelope_to` is used, regardless of multiple recipients in the EML header.
 
-また、EMLのヘッダ `Date:` の値は「配送予約時刻」として `mail_queues` テーブルの `timer_at` カラムに格納されます。`Date:` が省略された場合は、`timer_at` には現在時刻が設定されます。
+Also, the value of the EML header `Date:` is stored in the `timer_at` column of the `mail_queues` table as the "scheduled delivery time". If `Date:` is omitted, the current time is set in `timer_at`.
 
 
-### 将来の拡張計画
+### Future Expansion Plans
 
-#### バウンス管理機能（次期マイルストーン）
+#### Bounce Management Feature (Next Milestone)
 
-配送後のバウンスを管理することで、実質的な到達性を向上させます。
-詳細は [BOUNCE_MANAGEMENT.md](BOUNCE_MANAGEMENT.md) を参照してください。
+Managing bounces after delivery will improve actual deliverability.
+See [BOUNCE_MANAGEMENT.md](BOUNCE_MANAGEMENT.md) for details.
 
-#### 想定される拡張機能
+#### Expected Expansion Features
 
-- 配信速度制御（レート制限）
-- 宛先ドメインごとの同時接続数制限
-- DKIM署名サポート
-- 配信統計ダッシュボード
-- Webhook通知
+- Delivery rate control (rate limiting)
+- Limit on concurrent connections per recipient domain
+- DKIM signature support
+- Delivery statistics dashboard
+- Webhook notifications
 
 ---
 
-## データベース設計
+## Database Design
 
-### 対応データベース
+### Supported Databases
 
-Verbena は複数のデータベースシステムをサポートします：
+Verbena supports multiple database systems:
 
-| Database | Version | Status |
-|----------|---------|--------|
-| MySQL    | 8.0+    | ✅ Supported |
-| MariaDB  | 10.6+   | ✅ Supported |
-| PostgreSQL | 13+   | ✅ Supported |
-| SQLite   | 3.x     | ✅ Supported |
+| Database   | Version | Status        |
+|------------|---------|---------------|
+| MySQL      | 8.0+    | ✅ Supported  |
+| MariaDB    | 10.6+   | ✅ Supported  |
+| PostgreSQL | 13+     | ✅ Supported  |
+| SQLite     | 3.x     | ✅ Supported  |
 
-### マイグレーションの互換性
+### Migration Compatibility
 
-すべてのマイグレーション（`db/migrate/`）は、以下の原則に従い、複数のデータベースで動作するように設計されています：
+All migrations (`db/migrate/`) are designed to work with multiple databases according to the following principles:
 
-- **MySQL 専用オプション（`after:`、`charset:`、`collation:`）は使用しない**: MySQL 固有の `after:` などでカラム並び順を制御・前提とせず、実際の並び順は各データベース実装に依存するものとして、ポータブルな Rails マイグレーション構文を採用
-- **型固有のオプションはアダプタ非依存**: `:text` 型に対する MySQL 固有のサイズ指定オプション（`limit:` など）のように、DB ごとに挙動が異なる指定は使わず、すべての DB で解釈可能なプレーンな型指定のみを使用
-- **SQL の直接記述を避ける**: `execute()` 句で vendor-specific SQL を使わないよう注意
+- **Do not use MySQL-specific options (`after:`, `charset:`, `collation:`)**: Do not control or assume column order with MySQL-specific options like `after:`; use portable Rails migration syntax, and treat actual order as DB-dependent.
+- **Type-specific options are adapter-independent**: Do not use DB-specific options like MySQL's size specifier for `:text` (`limit:`), only use plain type specifiers that are interpreted by all DBs.
+- **Avoid direct SQL**: Do not use vendor-specific SQL in `execute()` clauses.
 
-### データベースの可搬性に関する注意
+### Notes on Database Portability
 
-本プロジェクトの `db/schema.rb` は MySQL 環境を基準（リファレンス）として生成されています。そのため `charset: "utf8mb4"` などの MySQL 固有オプションが含まれています。
+This project's `db/schema.rb` is generated based on the MySQL environment (as reference). Therefore, MySQL-specific options like `charset: "utf8mb4"` are included.
 
-PostgreSQL や SQLite などの他データベースを使用する場合、`bin/rails db:schema:load`（または `bin/setup` 内の `db:prepare`）を実行するとこれらの固有オプションが原因でエラーになる可能性があります。
+If you use PostgreSQL or SQLite, running `bin/rails db:schema:load` (or `db:prepare` in `bin/setup`) may cause errors due to these options.
 
-**MySQL 以外のデータベースで環境構築を行う場合は、`db:schema:load` を介さない以下のコマンド（マイグレーションからの構築）を使用してください：**
+**When setting up the environment with databases other than MySQL, use the following commands (build from migrations) instead of `db:schema:load`:**
 
 ```sh
-# PostgreSQL / SQLite の場合
+# For PostgreSQL / SQLite
 $ bin/rails db:create
 $ bin/rails db:migrate
 ```
 
-### タイムゾーン方針 (UTC)
+### Timezone Policy (UTC)
 
-Verbena は一貫して UTC で動作するように設計されています：
+Verbena is designed to operate consistently in UTC:
 
-- **Rails アプリケーション**: 常に UTC で動作（`config.time_zone = 'UTC'`）
-- **データベース OS**: タイムゾーンを UTC（`TZ=UTC`）に固定
-- **MySQL/MariaDB**: `config/database.yml` で `init_command: "SET time_zone = '+00:00'"` を指定し、セッションのタイムゾーンを UTC に固定
-- **PostgreSQL**: `config/database.yml` で `variables: { timezone: 'UTC' }` を指定し、セッションタイムゾーンを UTC に固定
-- **SQLite**: セッション／データベースのタイムゾーン設定はなし。日時は Rails 側で UTC として生成・管理
+- **Rails application**: Always operates in UTC (`config.time_zone = 'UTC'`)
+- **Database OS**: Timezone fixed to UTC (`TZ=UTC`)
+- **MySQL/MariaDB**: Specify `init_command: "SET time_zone = '+00:00'"` in `config/database.yml` to fix session timezone to UTC
+- **PostgreSQL**: Specify `variables: { timezone: 'UTC' }` in `config/database.yml` to fix session timezone to UTC
+- **SQLite**: No session/database timezone setting. Datetimes are generated/managed as UTC on the Rails side
 
-#### プログラミングガイドライン
+#### Programming Guidelines
 
-- DB内の `NOW()` や `CURRENT_TIMESTAMP` などのタイムゾーンが影響する関数は使わず、Rails で生成した日時値をバインドして利用してください
-- 日時は常に UTC として扱い、表示時のみユーザーのタイムゾーンに変換します
+- Do not use DB functions affected by timezone such as `NOW()` or `CURRENT_TIMESTAMP`; always bind datetime values generated by Rails
+- Always treat datetimes as UTC, and convert to the user's timezone only when displaying
 
-### EML データの保存方針
+### EML Data Storage Policy
 
-EML (Raw email format) は `eml_sources.eml` カラムに保存されます。
+EML (Raw email format) is stored in the `eml_sources.eml` column.
 
-#### 現在の方針（互換性優先）
+#### Current Policy (Compatibility Priority)
 
-- データベースに保存する EML は plain `:text` 型を使用し、すべてのデータベースで互換性を確保しています
-- MySQL の `TEXT` 型は約 64 KiB、PostgreSQL と SQLite の `text` は事実上無制限です
-- 添付ファイルがない、または小さいメール（通常のビジネスメール）であれば、この制限内で対応可能です
+- EML stored in the database uses plain `:text` type for compatibility with all databases
+- MySQL's `TEXT` type is about 64 KiB; PostgreSQL and SQLite `text` is effectively unlimited
+- For emails without attachments or with small attachments (typical business emails), this is sufficient
 
-#### 将来の拡張計画（オブジェクトストレージ対応予定）
+#### Future Expansion Plan (Object Storage Support Planned)
 
-- より大きな EML ファイル（大きな添付ファイル付き）をサポートするために、オブジェクトストレージの利用を検討しています
-- その際は、EML 本体をストレージに保存し、DB にはメタデータと小さなプレビューのみを保持します
+- To support larger EML files (with large attachments), we are considering using object storage
+- In that case, the EML body will be stored in storage, and only metadata and a small preview will be kept in the DB
 
-## トークン運用ルール
+## Token Operation Rules
 
-Verbena のメールデータ入力（Rake/Web API）には Bearer トークン認証が必要です。トークン管理・運用上の注意点は以下の通りです。
+Bearer token authentication is required for Verbena's email data input (Rake/Web API). The following are notes on token management and operation.
 
-- トークンの発行・更新は管理者のみが行います。利用者は配布された `key` のみ使用し、作成や更新はできません。
-- 発行時はモデルのファクトリメソッド `Token.create_unique!` を使用してください。
-- `key` の値は機密情報です。対象利用者以外に見られないよう保護してください。
-- `label` は利用者の目印としてユニークな値を設定します。
-- 有効期限は `expires_at` に設定し、その時刻まで有効です（必須）。
-- 無効化は物理削除ではなく `revoked_at` をセットすることで行ってください（監査のため）。
-- 発行後の `key` の更新は禁止されています（UNIQUE制約違反時に他人のkeyの存在が推測できるため、セキュリティ上の理由です）。変更が必要な場合は既存トークンを `revoke!` して無効化し、新しいトークンを作成してください。
-- 期限切れトークンの一括無効化は Rake タスク `verbena:tokens:revoke_expired` を利用してください。
+- Only administrators can issue or update tokens. Users may only use the distributed `key` and cannot create or update tokens themselves.
+- When issuing, use the model factory method `Token.create_unique!`.
+- The value of `key` is confidential. Protect it so that it is not seen by anyone other than the intended user.
+- Set a unique value for `label` as a marker for the user.
+- Set the expiration date in `expires_at`; it is valid until that time (required).
+- Invalidate by setting `revoked_at` instead of physical deletion (for audit purposes).
+- Updating the `key` after issuance is prohibited (for security reasons, as the existence of another's key could be inferred from UNIQUE constraint violations). If a change is needed, revoke the existing token with `revoke!` and create a new one.
+- To bulk-revoke expired tokens, use the Rake task `verbena:tokens:revoke_expired`.
 
-作成例：
+Example:
 
 ```ruby
 Token.create_unique!(label: "hoge", key: "user-secret", expires_at: 1.year.from_now)
 ```
 
-期限切れトークンの無効化：
+Invalidate expired tokens:
 
 ```sh
-# ドライラン（何件無効化されるかを確認）
+# Dry run (check how many will be invalidated)
 $ bundle exec rake verbena:tokens:revoke_expired[dry]
 
-# 実行（expires_at を過ぎ、まだ revoked されていないトークンを revoked にする）
+# Execute (set tokens to revoked if expires_at has passed and not yet revoked)
 $ bundle exec rake verbena:tokens:revoke_expired
 ```

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -5,6 +5,7 @@
 ## 目次
 
 - [開発環境のセットアップ](#開発環境のセットアップ)
+- [I18n / ロケール](#i18n--ロケール)
 - [テスト](#テスト)
 - [アーキテクチャ](#アーキテクチャ)
 - [データベース設計](#データベース設計)
@@ -135,6 +136,24 @@ $ docker compose -f compose.yml -f compose.mysql.yml up -d
 ```sh
 $ docker compose -f compose.yml -f compose.mysql.yml exec web rails db:migrate:reset
 ```
+
+---
+
+## I18n / ロケール
+
+Verbena は日本語 (ja) / 英語 (en) の 2 言語に対応します。既定は英語です。
+
+- 既定ロケール: `en`
+- フォールバック: `ja -> en`
+- 設定場所: `config/application.rb`
+- ロケールファイル: `config/locales/*.yml`
+- 標準翻訳: `rails-i18n` gem を利用
+
+### 追加・更新の方針
+
+- 画面文言は `t("...")` を利用し、`config/locales/en.yml` と `config/locales/ja.yml` の両方にキーを追加します。
+- モデル名/属性名/エラーメッセージは `activerecord.*` 配下に整理します。
+- API メッセージは英語固定の方針です。
 
 ---
 

--- a/docs/ENVIRONMENT_VARIABLES.ja.md
+++ b/docs/ENVIRONMENT_VARIABLES.ja.md
@@ -1,0 +1,104 @@
+# Verbena 環境変数リファレンス
+
+Verbena アプリケーションの設定に用いられる環境変数を説明します。
+
+開発者向けの情報として、詳細な挙動や型、値の正規化については `config/initializers/verbena_env.rb` を参照してください。
+
+## データベース設定
+
+データベース接続情報は Rails の [config/database.yml](../config/database.yml) で参照されます。
+
+| 変数名 | 用途 | 必須/任意 | 既定値 | 説明 |
+|--------|------|-----------|--------|------|
+| DATABASE_ADAPTER | アダプタ選択 | 任意 (Compose は自動設定) | なし | mysql2 / postgresql / sqlite3 のいずれか。ローカルで直接 Rails を起動する場合は必須 |
+| DATABASE_NAME | DB ベース名 | 任意 | verbena | `#{DATABASE_NAME}_<environment>` の規約で各環境の DB 名を決定します |
+| DATABASE_HOST | DB ホスト | 任意 | 127.0.0.1 | DB ホスト名/アドレス。Compose では自動的にコンテナ名を指定します |
+| DATABASE_PORT | DB ポート | 任意 | アダプタ既定 (mysql2: 3306, postgresql: 5432) | DB ポート番号 |
+| DATABASE_FILE | SQLite ファイル | 任意 | storage/verbena_<environment>.sqlite3 | SQLite 使用時の DB ファイルパス |
+
+| 変数名 | 用途 | 必須/任意 | 既定値 | 説明 |
+|--------|------|-----------|--------|------|
+| VERBENA_DATABASE_USER | DBユーザー | 本番必須 | なし | DB接続ユーザー名 |
+| VERBENA_DATABASE_PASSWORD | DBパスワード | 本番必須 | なし | DB接続パスワード |
+
+開発環境（Docker Compose）では `VERBENA_DATABASE_*` を省略しても、各 DB オーバーレイがアダプタ固有の認証情報（例: MySQL なら `MYSQL_USER` / `MYSQL_PASSWORD`、PostgreSQL なら `POSTGRES_USER` / `POSTGRES_PASSWORD`）を設定するため、そのまま動作します。
+
+**注意**: 本番環境や Docker Compose を使わない環境などで initdb スクリプトを使わない場合は、アプリ側の DB 接続情報として `VERBENA_DATABASE_USER` / `VERBENA_DATABASE_PASSWORD` を設定してください。
+
+## 配送設定
+
+### 基本設定
+
+| 変数名 | 用途 | 必須/任意 | 既定値 | 説明 |
+|--------|------|-----------|--------|------|
+| VERBENA_DELIVERY_METHOD | 配送方式 | 任意 | test（開発）/smtp（本番） | smtp / test / file |
+| VERBENA_ENVELOPE_FROM_OVERRIDE | Envelope-From上書き | 任意 | なし | SMTPのenvelope-from強制上書き |
+| VERBENA_DELIVERY_MAX_RETRIES | 配送リトライ回数 | 任意 | 5 | ネットワークエラーや一時的なSMTP 4xx エラー発生時にジョブを再試行する最大回数（ActiveJob の `retry_on` に渡されます） |
+| VERBENA_DELIVERY_LOCK_TTL_SECONDS | 配送処理のロック基本期間（秒） | 任意 | 300 | 配信処理が `MailQueue.locked_until` として設定する基本のロック時間（秒）。試行回数に応じて乗算されます（attempt 1 => base * 1）。 |
+| VERBENA_DELIVERY_LOCK_MAX_SECONDS | 配送処理のロック最大期間（秒） | 任意 | 3600 | `VERBENA_DELIVERY_LOCK_TTL_SECONDS` を試行回数で乗算した値に対する上限（秒）。長時間の送信処理でもロックが過度に伸びないよう制限します。 |
+
+### SMTP設定
+
+SMTP配送（`VERBENA_DELIVERY_METHOD=smtp`）を使用する場合に必要な設定です。
+
+| 変数名 | 用途 | 必須/任意 | 既定値 | 説明 |
+|--------|------|-----------|--------|------|
+| VERBENA_DELIVERY_SMTP_ADDRESS | SMTPサーバ | smtp時必須 | なし | SMTP配送時のサーバアドレス |
+| VERBENA_DELIVERY_SMTP_PORT | SMTPポート | smtp時必須 | なし | SMTP配送時のポート番号 |
+| VERBENA_DELIVERY_SMTP_DOMAIN | SMTPドメイン | smtp時必須 | なし | SMTP配送時のHELOドメイン |
+| VERBENA_DELIVERY_SMTP_USER_NAME | SMTPユーザ名 | smtp時必須 | なし | SMTP認証ユーザ名 |
+| VERBENA_DELIVERY_SMTP_PASSWORD | SMTPパスワード | smtp時必須 | なし | SMTP認証パスワード |
+| VERBENA_DELIVERY_SMTP_AUTHENTICATION | SMTP認証方式 | smtp時必須 | なし | plain / login など |
+| VERBENA_DELIVERY_SMTP_ENABLE_STARTTLS_AUTO | STARTTLS有効 | 任意 | true | SMTPでSTARTTLSを有効化 |
+
+### ファイル配送設定
+
+ファイル配送（`VERBENA_DELIVERY_METHOD=file`）を使用する場合の設定です。
+
+| 変数名 | 用途 | 必須/任意 | 既定値 | 説明 |
+|--------|------|-----------|--------|------|
+| VERBENA_FILE_DELIVERY_DIR | ファイル配送先 | file時任意 | tmp/mails | fileモード時の保存先 |
+
+## API設定
+
+### ページネーション
+
+API で MailQueues のインデックスを取得する際のページネーション・パラメータの設定です。
+
+| 変数名 | 用途 | 必須/任意 | 既定値 | 説明 |
+|--------|------|-----------|--------|------|
+| VERBENA_API_PAGINATION_DEFAULT_LIMIT | APIページネーション既定件数 | 任意 | 50 | APIレスポンスのデフォルト件数 |
+| VERBENA_API_PAGINATION_LIMIT_CAP | APIページネーション上限 | 任意 | 1000 | APIレスポンスの最大件数 |
+| VERBENA_API_PAGINATION_DEFAULT_OFFSET | APIページネーション既定オフセット | 任意 | 0 | APIレスポンスのデフォルトオフセット |
+
+### レスポンス埋め込み（responses）上限
+
+API で MailQueue のレコードを取得する際に、その配送レスポンスの情報（DeliveryResponses）を含める場合（パラメータに `include=responses` を指定した場合）の、その件数についての設定です。
+
+| 変数名 | 用途 | 必須/任意 | 既定値 | 説明 |
+|--------|------|-----------|--------|------|
+| VERBENA_API_RESPONSES_DEFAULT_LIMIT | 既定件数 | 任意 | 50 | 含める `responses` の既定取得件数。0 以下の値や未指定時はこの値が使われます |
+| VERBENA_API_RESPONSES_LIMIT_CAP | 取得上限 | 任意 | 100 | `responses_limit` パラメータが指定された場合の最大許容件数。これを超えるような再送信の試行が認められる場合は、リトライの設定を見直してください |
+
+## データ保守
+
+### サイズ制限
+
+| 変数名 | 用途 | 必須/任意 | 既定値 | 説明 |
+|--------|------|-----------|--------|------|
+| VERBENA_EML_MAX_BYTES | EML最大サイズ | 任意 | 10485760 | 受信EMLの最大バイト数 |
+
+### クリーンアップ
+
+| 変数名 | 用途 | 必須/任意 | 既定値 | 説明 |
+|--------|------|-----------|--------|------|
+| VERBENA_CLEANUP_TTL_DAYS | クリーンアップ保持日数 | 任意 | 30 | 配送済みデータの保持日数 |
+
+## システム設定
+
+| 変数名 | 用途 | 必須/任意 | 既定値 | 説明 |
+|--------|------|-----------|--------|------|
+| VERBENA_LOG_FORMAT | ログ出力形式 | 任意 | text | text / json |
+| VERBENA_ADMIN_USERNAME | 管理者ユーザー名 | 任意 | なし | Basic認証のユーザー名。未設定時は管理画面にアクセスできません |
+| VERBENA_ADMIN_PASSWORD | 管理者パスワード | 任意 | なし | Basic認証のパスワード。未設定時は管理画面にアクセスできません |
+| VERBENA_TOKEN | タスク用トークン | タスク実行時必須 | なし | `verbena:mail_queues:*` Rake タスクで使用する API トークン鍵 |

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -1,104 +1,104 @@
-# Verbena 環境変数リファレンス
+# Verbena Environment Variable Reference
 
-Verbena アプリケーションの設定に用いられる環境変数を説明します。
+This document describes the environment variables used to configure the Verbena application.
 
-開発者向けの情報として、詳細な挙動や型、値の正規化については `config/initializers/verbena_env.rb` を参照してください。
+For developer-oriented details, such as behavior, types, and value normalization, see `config/initializers/verbena_env.rb`.
 
-## データベース設定
+## Database Settings
 
-データベース接続情報は Rails の [config/database.yml](../config/database.yml) で参照されます。
+Database connection information is referenced by Rails in [config/database.yml](../config/database.yml).
 
-| 変数名 | 用途 | 必須/任意 | 既定値 | 説明 |
-|--------|------|-----------|--------|------|
-| DATABASE_ADAPTER | アダプタ選択 | 任意 (Compose は自動設定) | なし | mysql2 / postgresql / sqlite3 のいずれか。ローカルで直接 Rails を起動する場合は必須 |
-| DATABASE_NAME | DB ベース名 | 任意 | verbena | `#{DATABASE_NAME}_<environment>` の規約で各環境の DB 名を決定します |
-| DATABASE_HOST | DB ホスト | 任意 | 127.0.0.1 | DB ホスト名/アドレス。Compose では自動的にコンテナ名を指定します |
-| DATABASE_PORT | DB ポート | 任意 | アダプタ既定 (mysql2: 3306, postgresql: 5432) | DB ポート番号 |
-| DATABASE_FILE | SQLite ファイル | 任意 | storage/verbena_<environment>.sqlite3 | SQLite 使用時の DB ファイルパス |
+| Variable Name | Purpose | Required/Optional | Default | Description |
+|--------------|---------|------------------|---------|-------------|
+| DATABASE_ADAPTER | Adapter selection | Optional (auto-set by Compose) | None | One of mysql2 / postgresql / sqlite3. Required if running Rails directly locally |
+| DATABASE_NAME | DB base name | Optional | verbena | Determines the DB name for each environment as `#{DATABASE_NAME}_<environment>` |
+| DATABASE_HOST | DB host | Optional | 127.0.0.1 | DB hostname/address. Compose automatically sets the container name |
+| DATABASE_PORT | DB port | Optional | Adapter default (mysql2: 3306, postgresql: 5432) | DB port number |
+| DATABASE_FILE | SQLite file | Optional | storage/verbena_<environment>.sqlite3 | DB file path when using SQLite |
 
-| 変数名 | 用途 | 必須/任意 | 既定値 | 説明 |
-|--------|------|-----------|--------|------|
-| VERBENA_DATABASE_USER | DBユーザー | 本番必須 | なし | DB接続ユーザー名 |
-| VERBENA_DATABASE_PASSWORD | DBパスワード | 本番必須 | なし | DB接続パスワード |
+| Variable Name | Purpose | Required/Optional | Default | Description |
+|--------------|---------|------------------|---------|-------------|
+| VERBENA_DATABASE_USER | DB user | Required in production | None | DB connection username |
+| VERBENA_DATABASE_PASSWORD | DB password | Required in production | None | DB connection password |
 
-開発環境（Docker Compose）では `VERBENA_DATABASE_*` を省略しても、各 DB オーバーレイがアダプタ固有の認証情報（例: MySQL なら `MYSQL_USER` / `MYSQL_PASSWORD`、PostgreSQL なら `POSTGRES_USER` / `POSTGRES_PASSWORD`）を設定するため、そのまま動作します。
+In development (Docker Compose), you can omit `VERBENA_DATABASE_*` because each DB overlay sets adapter-specific credentials (e.g., `MYSQL_USER` / `MYSQL_PASSWORD` for MySQL, `POSTGRES_USER` / `POSTGRES_PASSWORD` for PostgreSQL), so it works as is.
 
-**注意**: 本番環境や Docker Compose を使わない環境などで initdb スクリプトを使わない場合は、アプリ側の DB 接続情報として `VERBENA_DATABASE_USER` / `VERBENA_DATABASE_PASSWORD` を設定してください。
+**Note**: In production or environments not using Docker Compose (where initdb scripts are not used), set `VERBENA_DATABASE_USER` / `VERBENA_DATABASE_PASSWORD` for the app's DB connection.
 
-## 配送設定
+## Delivery Settings
 
-### 基本設定
+### Basic Settings
 
-| 変数名 | 用途 | 必須/任意 | 既定値 | 説明 |
-|--------|------|-----------|--------|------|
-| VERBENA_DELIVERY_METHOD | 配送方式 | 任意 | test（開発）/smtp（本番） | smtp / test / file |
-| VERBENA_ENVELOPE_FROM_OVERRIDE | Envelope-From上書き | 任意 | なし | SMTPのenvelope-from強制上書き |
-| VERBENA_DELIVERY_MAX_RETRIES | 配送リトライ回数 | 任意 | 5 | ネットワークエラーや一時的なSMTP 4xx エラー発生時にジョブを再試行する最大回数（ActiveJob の `retry_on` に渡されます） |
-| VERBENA_DELIVERY_LOCK_TTL_SECONDS | 配送処理のロック基本期間（秒） | 任意 | 300 | 配信処理が `MailQueue.locked_until` として設定する基本のロック時間（秒）。試行回数に応じて乗算されます（attempt 1 => base * 1）。 |
-| VERBENA_DELIVERY_LOCK_MAX_SECONDS | 配送処理のロック最大期間（秒） | 任意 | 3600 | `VERBENA_DELIVERY_LOCK_TTL_SECONDS` を試行回数で乗算した値に対する上限（秒）。長時間の送信処理でもロックが過度に伸びないよう制限します。 |
+| Variable Name | Purpose | Required/Optional | Default | Description |
+|--------------|---------|------------------|---------|-------------|
+| VERBENA_DELIVERY_METHOD | Delivery method | Optional | test (development) / smtp (production) | smtp / test / file |
+| VERBENA_ENVELOPE_FROM_OVERRIDE | Envelope-From override | Optional | None | Force override of SMTP envelope-from |
+| VERBENA_DELIVERY_MAX_RETRIES | Delivery retry count | Optional | 5 | Maximum number of retries for network errors or temporary SMTP 4xx errors (passed to ActiveJob's `retry_on`) |
+| VERBENA_DELIVERY_LOCK_TTL_SECONDS | Base lock period for delivery (seconds) | Optional | 300 | Base lock time (seconds) set as `MailQueue.locked_until` for delivery processing. Multiplied by attempt count (attempt 1 => base * 1). |
+| VERBENA_DELIVERY_LOCK_MAX_SECONDS | Max lock period for delivery (seconds) | Optional | 3600 | Upper limit (seconds) for the value of `VERBENA_DELIVERY_LOCK_TTL_SECONDS` multiplied by attempt count. Prevents excessive lock extension for long sends. |
 
-### SMTP設定
+### SMTP Settings
 
-SMTP配送（`VERBENA_DELIVERY_METHOD=smtp`）を使用する場合に必要な設定です。
+These settings are required when using SMTP delivery (`VERBENA_DELIVERY_METHOD=smtp`).
 
-| 変数名 | 用途 | 必須/任意 | 既定値 | 説明 |
-|--------|------|-----------|--------|------|
-| VERBENA_DELIVERY_SMTP_ADDRESS | SMTPサーバ | smtp時必須 | なし | SMTP配送時のサーバアドレス |
-| VERBENA_DELIVERY_SMTP_PORT | SMTPポート | smtp時必須 | なし | SMTP配送時のポート番号 |
-| VERBENA_DELIVERY_SMTP_DOMAIN | SMTPドメイン | smtp時必須 | なし | SMTP配送時のHELOドメイン |
-| VERBENA_DELIVERY_SMTP_USER_NAME | SMTPユーザ名 | smtp時必須 | なし | SMTP認証ユーザ名 |
-| VERBENA_DELIVERY_SMTP_PASSWORD | SMTPパスワード | smtp時必須 | なし | SMTP認証パスワード |
-| VERBENA_DELIVERY_SMTP_AUTHENTICATION | SMTP認証方式 | smtp時必須 | なし | plain / login など |
-| VERBENA_DELIVERY_SMTP_ENABLE_STARTTLS_AUTO | STARTTLS有効 | 任意 | true | SMTPでSTARTTLSを有効化 |
+| Variable Name | Purpose | Required/Optional | Default | Description |
+|--------------|---------|------------------|---------|-------------|
+| VERBENA_DELIVERY_SMTP_ADDRESS | SMTP server | Required for smtp | None | Server address for SMTP delivery |
+| VERBENA_DELIVERY_SMTP_PORT | SMTP port | Required for smtp | None | Port number for SMTP delivery |
+| VERBENA_DELIVERY_SMTP_DOMAIN | SMTP domain | Required for smtp | None | HELO domain for SMTP delivery |
+| VERBENA_DELIVERY_SMTP_USER_NAME | SMTP username | Required for smtp | None | SMTP authentication username |
+| VERBENA_DELIVERY_SMTP_PASSWORD | SMTP password | Required for smtp | None | SMTP authentication password |
+| VERBENA_DELIVERY_SMTP_AUTHENTICATION | SMTP authentication method | Required for smtp | None | plain / login, etc. |
+| VERBENA_DELIVERY_SMTP_ENABLE_STARTTLS_AUTO | Enable STARTTLS | Optional | true | Enable STARTTLS for SMTP |
 
-### ファイル配送設定
+### File Delivery Settings
 
-ファイル配送（`VERBENA_DELIVERY_METHOD=file`）を使用する場合の設定です。
+Settings for file delivery (`VERBENA_DELIVERY_METHOD=file`).
 
-| 変数名 | 用途 | 必須/任意 | 既定値 | 説明 |
-|--------|------|-----------|--------|------|
-| VERBENA_FILE_DELIVERY_DIR | ファイル配送先 | file時任意 | tmp/mails | fileモード時の保存先 |
+| Variable Name | Purpose | Required/Optional | Default | Description |
+|--------------|---------|------------------|---------|-------------|
+| VERBENA_FILE_DELIVERY_DIR | File delivery destination | Optional for file | tmp/mails | Save destination in file mode |
 
-## API設定
+## API Settings
 
-### ページネーション
+### Pagination
 
-API で MailQueues のインデックスを取得する際のページネーション・パラメータの設定です。
+Settings for pagination parameters when retrieving MailQueues index via API.
 
-| 変数名 | 用途 | 必須/任意 | 既定値 | 説明 |
-|--------|------|-----------|--------|------|
-| VERBENA_API_PAGINATION_DEFAULT_LIMIT | APIページネーション既定件数 | 任意 | 50 | APIレスポンスのデフォルト件数 |
-| VERBENA_API_PAGINATION_LIMIT_CAP | APIページネーション上限 | 任意 | 1000 | APIレスポンスの最大件数 |
-| VERBENA_API_PAGINATION_DEFAULT_OFFSET | APIページネーション既定オフセット | 任意 | 0 | APIレスポンスのデフォルトオフセット |
+| Variable Name | Purpose | Required/Optional | Default | Description |
+|--------------|---------|------------------|---------|-------------|
+| VERBENA_API_PAGINATION_DEFAULT_LIMIT | API pagination default count | Optional | 50 | Default number of items in API response |
+| VERBENA_API_PAGINATION_LIMIT_CAP | API pagination upper limit | Optional | 1000 | Maximum number of items in API response |
+| VERBENA_API_PAGINATION_DEFAULT_OFFSET | API pagination default offset | Optional | 0 | Default offset in API response |
 
-### レスポンス埋め込み（responses）上限
+### Response Embedding (responses) Limit
 
-API で MailQueue のレコードを取得する際に、その配送レスポンスの情報（DeliveryResponses）を含める場合（パラメータに `include=responses` を指定した場合）の、その件数についての設定です。
+Settings for the number of delivery responses (DeliveryResponses) included when retrieving MailQueue records via API (when `include=responses` parameter is specified).
 
-| 変数名 | 用途 | 必須/任意 | 既定値 | 説明 |
-|--------|------|-----------|--------|------|
-| VERBENA_API_RESPONSES_DEFAULT_LIMIT | 既定件数 | 任意 | 50 | 含める `responses` の既定取得件数。0 以下の値や未指定時はこの値が使われます |
-| VERBENA_API_RESPONSES_LIMIT_CAP | 取得上限 | 任意 | 100 | `responses_limit` パラメータが指定された場合の最大許容件数。これを超えるような再送信の試行が認められる場合は、リトライの設定を見直してください |
+| Variable Name | Purpose | Required/Optional | Default | Description |
+|--------------|---------|------------------|---------|-------------|
+| VERBENA_API_RESPONSES_DEFAULT_LIMIT | Default count | Optional | 50 | Default number of `responses` to include. Used if value is 0 or not specified |
+| VERBENA_API_RESPONSES_LIMIT_CAP | Upper limit | Optional | 100 | Maximum allowed if `responses_limit` parameter is specified. If more retries are needed, review retry settings |
 
-## データ保守
+## Data Maintenance
 
-### サイズ制限
+### Size Limit
 
-| 変数名 | 用途 | 必須/任意 | 既定値 | 説明 |
-|--------|------|-----------|--------|------|
-| VERBENA_EML_MAX_BYTES | EML最大サイズ | 任意 | 10485760 | 受信EMLの最大バイト数 |
+| Variable Name | Purpose | Required/Optional | Default | Description |
+|--------------|---------|------------------|---------|-------------|
+| VERBENA_EML_MAX_BYTES | Max EML size | Optional | 10485760 | Maximum bytes for received EML |
 
-### クリーンアップ
+### Cleanup
 
-| 変数名 | 用途 | 必須/任意 | 既定値 | 説明 |
-|--------|------|-----------|--------|------|
-| VERBENA_CLEANUP_TTL_DAYS | クリーンアップ保持日数 | 任意 | 30 | 配送済みデータの保持日数 |
+| Variable Name | Purpose | Required/Optional | Default | Description |
+|--------------|---------|------------------|---------|-------------|
+| VERBENA_CLEANUP_TTL_DAYS | Cleanup retention days | Optional | 30 | Retention days for delivered data |
 
-## システム設定
+## System Settings
 
-| 変数名 | 用途 | 必須/任意 | 既定値 | 説明 |
-|--------|------|-----------|--------|------|
-| VERBENA_LOG_FORMAT | ログ出力形式 | 任意 | text | text / json |
-| VERBENA_ADMIN_USERNAME | 管理者ユーザー名 | 任意 | なし | Basic認証のユーザー名。未設定時は管理画面にアクセスできません |
-| VERBENA_ADMIN_PASSWORD | 管理者パスワード | 任意 | なし | Basic認証のパスワード。未設定時は管理画面にアクセスできません |
-| VERBENA_TOKEN | タスク用トークン | タスク実行時必須 | なし | `verbena:mail_queues:*` Rake タスクで使用する API トークン鍵 |
+| Variable Name | Purpose | Required/Optional | Default | Description |
+|--------------|---------|------------------|---------|-------------|
+| VERBENA_LOG_FORMAT | Log output format | Optional | text | text / json |
+| VERBENA_ADMIN_USERNAME | Admin username | Optional | None | Username for Basic authentication. If unset, cannot access admin UI |
+| VERBENA_ADMIN_PASSWORD | Admin password | Optional | None | Password for Basic authentication. If unset, cannot access admin UI |
+| VERBENA_TOKEN | Token for tasks | Required for task execution | None | API token key used in `verbena:mail_queues:*` Rake tasks |

--- a/docs/FAQ.ja.md
+++ b/docs/FAQ.ja.md
@@ -1,0 +1,183 @@
+(Claude Sonnet 4.5 作成、 GPT-5.2-Codex 修正)
+---
+
+# Verbena FAQ
+
+## 配送保証について
+
+### Q. 最終的にユーザーの受信箱に届いたか分かりますか？
+
+**A. いいえ、Verbenaが保証するのは「配送先SMTPサーバへの引き渡しまで」です。**
+
+SMTPプロトコルの仕様上、以下のような制約があります：
+
+1. SMTPサーバが「250 OK」を返した時点で、そのサーバがメールを受理したことになります
+2. その後のリレー先での配送や、最終的な受信箱への格納は、受け取ったサーバ側の責任です
+3. リレー先でのバウンスや受信箱到達は、Verbenaからは直接検知できません
+
+これはVerbenaに限らず、ほぼすべてのメール配信システム（商用SaaS含む）に共通する制約です。
+
+### Q. それではユーザーに届かなくても分からないのですか？
+
+**A. バウンス（配送失敗通知）を管理することで、実質的な到達性を高められます。**
+
+リレー先で配送に失敗した場合、通常は「バウンスメール（DSN: Delivery Status Notification）」が Return-Path アドレスに返送されます。
+
+Verbenaでは、次期マイルストーンとして **バウンス管理機能** の実装を計画しています：
+
+1. バウンスメールを自動的に収集・解析（[Sisimai](https://sisimai.org/) を使用）
+2. 配送不能アドレスをブラックリストに登録
+3. 次回配信時に自動的に除外
+
+詳細は [BOUNCE_MANAGEMENT.ja.md](BOUNCE_MANAGEMENT.ja.md) を参照してください。
+
+### Q. メールを開封したかどうか追跡できますか？
+
+**A. Verbenaには開封追跡機能はありません。**
+
+メール開封の追跡には、以下のような別の仕組みが必要です：
+
+- HTMLメール内にトラッキングピクセル（透明な1x1画像）を埋め込む
+- リンククリックの計測（URLを独自のトラッキングサーバ経由に変換）
+
+ただし、これらの方法には限界があります：
+
+- メーラーが画像を自動表示しない設定の場合、検知できない
+- プライバシー保護機能（iOS Mail Privacy Protection等）で無効化される
+- 法的規制（GDPRなど）への配慮が必要
+
+Verbenaの責務範囲は「SMTP配送管理」であり、開封追跡は対象外としています。
+
+## バウンス管理について
+
+### Q. バウンスはリアルタイムで検知できますか？
+
+**A. SMTPレベルの即時エラー（4xx/5xx）は検知できますが、リレー先でのバウンスは遅延があります。**
+
+**即時に検知できるもの**:
+- 配送先SMTPサーバからの即時拒否（例: 554 Relay access denied）
+- アドレス形式不正による例外（Net::SMTPSyntaxError）
+
+**遅延して検知されるもの**:
+- リレー先サーバでのバウンス（数分〜数時間後）
+- スパムフィルタによるドロップ（バウンスが返らない場合も）
+
+バウンス管理機能では、定期的（例: 毎時）にバウンスメールを収集・解析する方式を想定しています。
+
+### Q. 一時的なエラー（4xx）と恒久的なエラー（5xx）はどう扱いますか？
+
+**A. 将来的には「一時的エラーは再送、恒久的エラーはブラックリスト登録」が基本方針です。**
+
+**4xx（一時的エラー）の例**:
+- 450 Mailbox full（メールボックス満杯）
+- 451 Temporary local problem（一時的な問題）
+- 452 Insufficient storage（サーバ側の容量不足）
+
+→ 将来的に一定期間・回数まで再送を試みます
+
+**5xx（恒久的エラー）の例**:
+- 550 User unknown（ユーザー不明）
+- 551 User not local（ユーザーが存在しない）
+- 554 Message rejected（スパム判定等）
+
+→ 将来的にブラックリストへ登録し、以降の配信を停止します
+
+## システム設計について
+
+### Q. なぜ SolidQueue を採用したのですか？
+
+**A. Rails標準機能であり、信頼性とメンテナンス性が高いためです。**
+
+以前は独自のDBポーリングとロック機構（Claim機能）を実装していましたが、Rails 8 で標準搭載された SolidQueue へ移行しました。
+これにより、複雑なロック管理やデッドロック対策のメンテナンスコストを削減し、標準的な非同期処理パターンを利用できるようになりました。
+
+### Q. 他の配信システムと連携できますか？
+
+**A. バウンスリスト参照については、将来的にAPI公開を予定しています。**
+
+バウンス管理機能（Phase 3）では、ブラックリストをREST API経由で参照できるようにする予定です。
+これにより、Verbenaの配信機能を使わず、ブラックリスト管理だけを他システムで利用することも可能になります。
+
+詳細は [BOUNCE_MANAGEMENT.ja.md](BOUNCE_MANAGEMENT.ja.md) を参照してください。
+
+## 運用について
+
+### Q. 大量配信時のパフォーマンスはどうですか？
+
+**A. SolidQueue のワーカー数などの並行数を調整することで、スケールします。**
+
+以下の設定で調整可能です：
+
+```yaml
+# config/queue.yml
+workers:
+   - queues: "*"
+      threads: 3
+      processes: <%= ENV.fetch("JOB_CONCURRENCY", 1) %>
+```
+
+実際のスループットは、SMTPサーバの性能やネットワーク環境に依存します。
+
+### Q. 処理が止まったジョブはどうなりますか？
+
+**A. SolidQueue が管理し、失敗したジョブは `solid_queue_failed_executions` テーブルに記録されます。**
+
+以下の手段で確認・再試行が可能です：
+
+```ruby
+# 失敗したジョブの確認
+SolidQueue::FailedExecution.count
+SolidQueue::FailedExecution.last.error
+
+# 失敗したジョブの再試行
+SolidQueue::FailedExecution.last.retry
+```
+
+### Q. ログはどのように管理すれば良いですか？
+
+**A. JSON形式の構造化ログ出力に対応しています。**
+
+環境変数 `VERBENA_LOG_FORMAT=json` を設定すると JSON Lines 形式で出力できます。
+これにより、Fluentd / Logstash / CloudWatch Logs などでの集約・分析が容易になります。
+
+```json
+{"event":"deliver.result","level":"info","mail_queue_id":42,"message_id":"<xyz@example.com>","smtp_status":"250","message":"OK sending..."}
+```
+
+## トラブルシューティング
+
+### Q. 配信が止まっているようです
+
+**確認事項**:
+
+1. **滞留しているジョブの確認**
+   ```ruby
+   SolidQueue::Job.count
+   SolidQueue::ScheduledExecution.count  # 予約実行待ち
+   SolidQueue::ReadyExecution.count      # 実行待ち
+   SolidQueue::ClaimedExecution.count    # 実行中
+   ```
+
+2. **失敗したジョブの確認**
+   ```ruby
+   SolidQueue::FailedExecution.count
+   ```
+   エラー詳細を確認してください。
+
+3. **ログの確認**
+   ```bash
+   tail -f log/production.log | grep deliver
+   ```
+
+4. **DeliveryResponse の確認**
+   ```ruby
+   DeliveryResponse.where('created_at > ?', 1.hour.ago).group(:status).count
+   ```
+
+### Q. Docker環境でビルドが失敗します
+
+**よくある原因**:
+
+1. **ネットワーク不通**: rubygems.org や Docker Hub へのアクセスが必要です
+2. **DB起動待ち**: `docker compose up -d` 後、約60秒待ってから `rails db:migrate` を実行
+3. **ポート競合**: ポート3000が既に使われていないか確認

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,183 +1,183 @@
-(Claude Sonnet 4.5 作成、 GPT-5.2-Codex 修正)
+(Created by Claude Sonnet 4.5, revised by GPT-5.2-Codex)
 ---
 
 # Verbena FAQ
 
-## 配送保証について
+## Delivery Guarantees
 
-### Q. 最終的にユーザーの受信箱に届いたか分かりますか？
+### Q. Can I know if the email actually reached the user's inbox?
 
-**A. いいえ、Verbenaが保証するのは「配送先SMTPサーバへの引き渡しまで」です。**
+**A. No, Verbena only guarantees delivery up to the destination SMTP server.**
 
-SMTPプロトコルの仕様上、以下のような制約があります：
+Due to the SMTP protocol specification, there are the following limitations:
 
-1. SMTPサーバが「250 OK」を返した時点で、そのサーバがメールを受理したことになります
-2. その後のリレー先での配送や、最終的な受信箱への格納は、受け取ったサーバ側の責任です
-3. リレー先でのバウンスや受信箱到達は、Verbenaからは直接検知できません
+1. When the SMTP server returns "250 OK", it means the server has accepted the email
+2. Subsequent relaying and final inbox delivery are the responsibility of the receiving server
+3. Bounces or inbox delivery at relay servers cannot be directly detected by Verbena
 
-これはVerbenaに限らず、ほぼすべてのメール配信システム（商用SaaS含む）に共通する制約です。
+This is a limitation common to almost all email delivery systems (including commercial SaaS), not just Verbena.
 
-### Q. それではユーザーに届かなくても分からないのですか？
+### Q. So, does that mean I can't know if the user actually received the email?
 
-**A. バウンス（配送失敗通知）を管理することで、実質的な到達性を高められます。**
+**A. By managing bounces (delivery failure notifications), you can improve practical deliverability.**
 
-リレー先で配送に失敗した場合、通常は「バウンスメール（DSN: Delivery Status Notification）」が Return-Path アドレスに返送されます。
+If delivery fails at a relay, a "bounce email" (DSN: Delivery Status Notification) is usually returned to the Return-Path address.
 
-Verbenaでは、次期マイルストーンとして **バウンス管理機能** の実装を計画しています：
+Verbena plans to implement a **bounce management feature** as a future milestone:
 
-1. バウンスメールを自動的に収集・解析（[Sisimai](https://sisimai.org/) を使用）
-2. 配送不能アドレスをブラックリストに登録
-3. 次回配信時に自動的に除外
+1. Automatically collect and parse bounce emails (using [Sisimai](https://sisimai.org/))
+2. Register undeliverable addresses to a blacklist
+3. Automatically exclude them from future deliveries
 
-詳細は [BOUNCE_MANAGEMENT.md](BOUNCE_MANAGEMENT.md) を参照してください。
+See [BOUNCE_MANAGEMENT.md](BOUNCE_MANAGEMENT.md) for details.
 
-### Q. メールを開封したかどうか追跡できますか？
+### Q. Can I track whether an email was opened?
 
-**A. Verbenaには開封追跡機能はありません。**
+**A. Verbena does not have an open tracking feature.**
 
-メール開封の追跡には、以下のような別の仕組みが必要です：
+Tracking email opens requires other mechanisms, such as:
 
-- HTMLメール内にトラッキングピクセル（透明な1x1画像）を埋め込む
-- リンククリックの計測（URLを独自のトラッキングサーバ経由に変換）
+- Embedding a tracking pixel (transparent 1x1 image) in HTML emails
+- Measuring link clicks (converting URLs to go through a tracking server)
 
-ただし、これらの方法には限界があります：
+However, these methods have limitations:
 
-- メーラーが画像を自動表示しない設定の場合、検知できない
-- プライバシー保護機能（iOS Mail Privacy Protection等）で無効化される
-- 法的規制（GDPRなど）への配慮が必要
+- If the mail client is set not to display images automatically, opens cannot be detected
+- Privacy protection features (such as iOS Mail Privacy Protection) can disable tracking
+- Legal regulations (such as GDPR) must be considered
 
-Verbenaの責務範囲は「SMTP配送管理」であり、開封追跡は対象外としています。
+Verbena's responsibility is "SMTP delivery management"; open tracking is out of scope.
 
-## バウンス管理について
+## Bounce Management
 
-### Q. バウンスはリアルタイムで検知できますか？
+### Q. Can bounces be detected in real time?
 
-**A. SMTPレベルの即時エラー（4xx/5xx）は検知できますが、リレー先でのバウンスは遅延があります。**
+**A. Immediate SMTP-level errors (4xx/5xx) can be detected, but bounces at relay servers are delayed.**
 
-**即時に検知できるもの**:
-- 配送先SMTPサーバからの即時拒否（例: 554 Relay access denied）
-- アドレス形式不正による例外（Net::SMTPSyntaxError）
+**Detected immediately:**
+- Immediate rejection from the destination SMTP server (e.g., 554 Relay access denied)
+- Exceptions due to invalid address format (Net::SMTPSyntaxError)
 
-**遅延して検知されるもの**:
-- リレー先サーバでのバウンス（数分〜数時間後）
-- スパムフィルタによるドロップ（バウンスが返らない場合も）
+**Detected with delay:**
+- Bounces at relay servers (minutes to hours later)
+- Drops by spam filters (sometimes no bounce is returned)
 
-バウンス管理機能では、定期的（例: 毎時）にバウンスメールを収集・解析する方式を想定しています。
+The bounce management feature is expected to periodically (e.g., hourly) collect and parse bounce emails.
 
-### Q. 一時的なエラー（4xx）と恒久的なエラー（5xx）はどう扱いますか？
+### Q. How are temporary errors (4xx) and permanent errors (5xx) handled?
 
-**A. 将来的には「一時的エラーは再送、恒久的エラーはブラックリスト登録」が基本方針です。**
+**A. The basic policy is: temporary errors are retried, permanent errors are blacklisted (planned for the future).**
 
-**4xx（一時的エラー）の例**:
-- 450 Mailbox full（メールボックス満杯）
-- 451 Temporary local problem（一時的な問題）
-- 452 Insufficient storage（サーバ側の容量不足）
+**Examples of 4xx (temporary errors):**
+- 450 Mailbox full
+- 451 Temporary local problem
+- 452 Insufficient storage
 
-→ 将来的に一定期間・回数まで再送を試みます
+→ Will be retried for a certain period/number of times in the future
 
-**5xx（恒久的エラー）の例**:
-- 550 User unknown（ユーザー不明）
-- 551 User not local（ユーザーが存在しない）
-- 554 Message rejected（スパム判定等）
+**Examples of 5xx (permanent errors):**
+- 550 User unknown
+- 551 User not local
+- 554 Message rejected
 
-→ 将来的にブラックリストへ登録し、以降の配信を停止します
+→ Will be blacklisted in the future, and further deliveries will be stopped
 
-## システム設計について
+## System Design
 
-### Q. なぜ SolidQueue を採用したのですか？
+### Q. Why did you choose SolidQueue?
 
-**A. Rails標準機能であり、信頼性とメンテナンス性が高いためです。**
+**A. Because it is a Rails standard feature, offering high reliability and maintainability.**
 
-以前は独自のDBポーリングとロック機構（Claim機能）を実装していましたが、Rails 8 で標準搭載された SolidQueue へ移行しました。
-これにより、複雑なロック管理やデッドロック対策のメンテナンスコストを削減し、標準的な非同期処理パターンを利用できるようになりました。
+Previously, we implemented our own DB polling and locking mechanism (Claim feature), but with Rails 8, we migrated to the standard SolidQueue.
+This reduced the maintenance cost of complex lock management and deadlock prevention, and enabled us to use standard asynchronous processing patterns.
 
-### Q. 他の配信システムと連携できますか？
+### Q. Can Verbena integrate with other delivery systems?
 
-**A. バウンスリスト参照については、将来的にAPI公開を予定しています。**
+**A. For bounce list reference, we plan to provide an API in the future.**
 
-バウンス管理機能（Phase 3）では、ブラックリストをREST API経由で参照できるようにする予定です。
-これにより、Verbenaの配信機能を使わず、ブラックリスト管理だけを他システムで利用することも可能になります。
+In the bounce management feature (Phase 3), we plan to make the blacklist accessible via REST API.
+This will allow other systems to use only the blacklist management, even without using Verbena's delivery features.
 
-詳細は [BOUNCE_MANAGEMENT.md](BOUNCE_MANAGEMENT.md) を参照してください。
+See [BOUNCE_MANAGEMENT.md](BOUNCE_MANAGEMENT.md) for details.
 
-## 運用について
+## Operations
 
-### Q. 大量配信時のパフォーマンスはどうですか？
+### Q. How is performance for large-scale delivery?
 
-**A. SolidQueue のワーカー数などの並行数を調整することで、スケールします。**
+**A. It scales by adjusting the number of SolidQueue workers and concurrency.**
 
-以下の設定で調整可能です：
+You can adjust with the following settings:
 
 ```yaml
 # config/queue.yml
 workers:
-   - queues: "*"
-      threads: 3
-      processes: <%= ENV.fetch("JOB_CONCURRENCY", 1) %>
+  - queues: "*"
+    threads: 3
+    processes: <%= ENV.fetch("JOB_CONCURRENCY", 1) %>
 ```
 
-実際のスループットは、SMTPサーバの性能やネットワーク環境に依存します。
+Actual throughput depends on the performance of the SMTP server and network environment.
 
-### Q. 処理が止まったジョブはどうなりますか？
+### Q. What happens to jobs that stop processing?
 
-**A. SolidQueue が管理し、失敗したジョブは `solid_queue_failed_executions` テーブルに記録されます。**
+**A. SolidQueue manages them, and failed jobs are recorded in the `solid_queue_failed_executions` table.**
 
-以下の手段で確認・再試行が可能です：
+You can check and retry with the following methods:
 
 ```ruby
-# 失敗したジョブの確認
+# Check failed jobs
 SolidQueue::FailedExecution.count
 SolidQueue::FailedExecution.last.error
 
-# 失敗したジョブの再試行
+# Retry failed jobs
 SolidQueue::FailedExecution.last.retry
 ```
 
-### Q. ログはどのように管理すれば良いですか？
+### Q. How should I manage logs?
 
-**A. JSON形式の構造化ログ出力に対応しています。**
+**A. Structured JSON log output is supported.**
 
-環境変数 `VERBENA_LOG_FORMAT=json` を設定すると JSON Lines 形式で出力できます。
-これにより、Fluentd / Logstash / CloudWatch Logs などでの集約・分析が容易になります。
+Set the environment variable `VERBENA_LOG_FORMAT=json` to output in JSON Lines format.
+This makes it easy to aggregate and analyze with Fluentd, Logstash, CloudWatch Logs, etc.
 
 ```json
 {"event":"deliver.result","level":"info","mail_queue_id":42,"message_id":"<xyz@example.com>","smtp_status":"250","message":"OK sending..."}
 ```
 
-## トラブルシューティング
+## Troubleshooting
 
-### Q. 配信が止まっているようです
+### Q. Delivery seems to be stuck
 
-**確認事項**:
+**Checklist:**
 
-1. **滞留しているジョブの確認**
+1. **Check for queued jobs**
    ```ruby
    SolidQueue::Job.count
-   SolidQueue::ScheduledExecution.count  # 予約実行待ち
-   SolidQueue::ReadyExecution.count      # 実行待ち
-   SolidQueue::ClaimedExecution.count    # 実行中
+   SolidQueue::ScheduledExecution.count  # Waiting for scheduled execution
+   SolidQueue::ReadyExecution.count      # Waiting for execution
+   SolidQueue::ClaimedExecution.count    # In progress
    ```
 
-2. **失敗したジョブの確認**
+2. **Check for failed jobs**
    ```ruby
    SolidQueue::FailedExecution.count
    ```
-   エラー詳細を確認してください。
+   Check the error details.
 
-3. **ログの確認**
+3. **Check logs**
    ```bash
    tail -f log/production.log | grep deliver
    ```
 
-4. **DeliveryResponse の確認**
+4. **Check DeliveryResponse**
    ```ruby
    DeliveryResponse.where('created_at > ?', 1.hour.ago).group(:status).count
    ```
 
-### Q. Docker環境でビルドが失敗します
+### Q. Build fails in Docker environment
 
-**よくある原因**:
+**Common causes:**
 
-1. **ネットワーク不通**: rubygems.org や Docker Hub へのアクセスが必要です
-2. **DB起動待ち**: `docker compose up -d` 後、約60秒待ってから `rails db:migrate` を実行
-3. **ポート競合**: ポート3000が既に使われていないか確認
+1. **Network unreachable**: Access to rubygems.org and Docker Hub is required
+2. **Waiting for DB startup**: After `docker compose up -d`, wait about 60 seconds before running `rails db:migrate`
+3. **Port conflict**: Make sure port 3000 is not already in use

--- a/lib/tasks/verbena/cleanup.rake
+++ b/lib/tasks/verbena/cleanup.rake
@@ -1,6 +1,6 @@
 namespace :verbena do
   namespace :cleanup do
-    desc '配送処理後、一ヶ月以上を経過した mail_queues と関連レコードを削除する'
+    desc 'Delete mail_queues and related records older than one month after delivery'
     task :monthly, [:dry] => :environment do |_task, args|
       begin
         service = Verbena::CleanupService.monthly(dry_run: Verbena::ServiceBase.truthy?(args[:dry]))
@@ -11,7 +11,7 @@ namespace :verbena do
       end
     end
 
-    desc '配送処理後、一週以上を経過した mail_queues と関連レコードを削除する'
+    desc 'Delete mail_queues and related records older than one week after delivery'
     task :weekly, [:dry] => :environment do |_task, args|
       begin
         service = Verbena::CleanupService.weekly(dry_run: Verbena::ServiceBase.truthy?(args[:dry]))
@@ -22,7 +22,7 @@ namespace :verbena do
       end
     end
 
-    desc '配送処理後、一日以上を経過した mail_queues と関連レコードを削除する'
+    desc 'Delete mail_queues and related records older than one day after delivery'
     task :daily, [:dry] => :environment do |_task, args|
       begin
         service = Verbena::CleanupService.daily(dry_run: Verbena::ServiceBase.truthy?(args[:dry]))
@@ -33,7 +33,7 @@ namespace :verbena do
       end
     end
 
-    desc '配送処理が済んでいる mail_queues と関連レコードを削除する'
+    desc 'Delete delivered mail_queues and related records'
     task :now, [:dry] => :environment do |_task, args|
       begin
         service = Verbena::CleanupService.new(dry_run: Verbena::ServiceBase.truthy?(args[:dry]))
@@ -44,7 +44,7 @@ namespace :verbena do
       end
     end
 
-    desc 'TTL 設定（VERBENA_CLEANUP_TTL_DAYS）に基づいてクリーンアップを実行（dry オプション対応）'
+    desc 'Run cleanup based on TTL setting (VERBENA_CLEANUP_TTL_DAYS) with dry option'
     task :by_ttl, [:dry] => :environment do |_task, args|
       begin
         service = Verbena::CleanupService.by_ttl(dry_run: Verbena::ServiceBase.truthy?(args[:dry]))

--- a/lib/tasks/verbena/delivery.rake
+++ b/lib/tasks/verbena/delivery.rake
@@ -1,6 +1,6 @@
 namespace :verbena do
   namespace :delivery do
-    desc '直近の配送がステータス4xxであったメッセージを再送キューに入れる'
+    desc 'Enqueue retryable messages whose last status was 4xx'
     task :prepare_retry => :environment do |_task, _args|
       puts "Searching for retryable messages (last status 4xx)..."
       count = 0
@@ -33,7 +33,7 @@ namespace :verbena do
       puts "\nEnqueued #{count} #{count == 1 ? 'job' : 'jobs'} for retry."
     end
 
-    desc '配送結果が無いメッセージを配送キューに入れる'
+    desc 'Enqueue messages with no delivery responses'
     task :reset_undelivered, [:older_than_hours] => :environment do |_task, args|
       older_than_arg = args[:older_than_hours]
       older_than_hours =

--- a/lib/tasks/verbena/mail_queues.rake
+++ b/lib/tasks/verbena/mail_queues.rake
@@ -19,7 +19,7 @@ namespace :verbena do
       end
     end
 
-    desc 'mail_queues に eml ファイルの内容を登録する'
+    desc 'Register an EML file into mail_queues'
     task :add, [:eml] => :environment do |task, args|
       begin
         extras = parse_extras(args)
@@ -36,7 +36,7 @@ namespace :verbena do
       end
     end
 
-    desc 'mail_queues に eml, envelope_from, envelope_to を登録する'
+    desc 'Register eml, envelope_from, and envelope_to into mail_queues'
     task :add_raw, [:eml, :envelope_from, :envelope_to] => :environment do |task, args|
       begin
         extras = parse_extras(args)
@@ -63,7 +63,7 @@ namespace :verbena do
       end
     end
 
-    desc 'mail_queues から指定した id のレコードを削除する'
+    desc 'Delete a mail_queue record by id'
     task :delete, [:mail_queue_id] => :environment do |task, args|
       begin
         extras = parse_extras(args)


### PR DESCRIPTION
(Grok Code First 1 にて PR 文の下地を作成、 GPT-4.1 にてチェックと修正)

## 概要
このPRでは、Verbenaプロジェクトに国際化（I18n）サポートを追加し、ドキュメントとUIのプライマリ言語を英語にしつつ、日本語翻訳を保持します。変更内容にはドキュメントの翻訳、`rails-i18n` gemの追加、I18n設定の構成、コントローラーとビューの翻訳キーへの更新が含まれます。これにより、グローバルなOSS貢献者にとってのアクセシビリティが向上します。

## 変更内容
- **ドキュメントの更新**:
  - `README.md` を英語をプライマリバージョンとして翻訳し、日本語コンテンツを `README.ja.md` に移動。
  - `CONTRIBUTING.md` を英語プライマリセクションに更新し、日本語を追加。
  - `docs/` ディレクトリのドキュメント（例: `ENVIRONMENT_VARIABLES.md`, `DEVELOPMENT.md`）を翻訳し、日本語版として `.ja.md` ファイルを別途作成。
  - 内部リンクを適切な言語バージョンに更新。

- **I18nの実装**:
  - `Gemfile` に `rails-i18n ~> 8.1` gemを追加し、Rails標準翻訳を利用可能に。
  - `config/application.rb` でI18nを設定: 利用可能ロケールを `[:en, :ja]` に、デフォルトロケールを `:en` に、フォールバックを `{ ja: [:ja, :en], en: [:en] }` に設定。
  - `config/environments/production.rb` で重複するフォールバックをコメントアウトし、設定を集中管理。
  - ロケールファイルを作成: `config/locales/en.yml` にページ、フラッシュメッセージ、エラー、ActiveRecord属性/モデルの包括的な翻訳を追加。
  - `app/controllers/eml_inputs_controller.rb` を更新し、ハードコードされた日本語文字列を `I18n.t` 呼び出しに置き換え。
  - ビュー（`app/views/eml_inputs/_form_body.html.erb`, `new.html.erb`, `app/views/top/index.html.erb`）を更新し、ラベル、プレースホルダー、メッセージに `t()` ヘルパーを使用。

## 動機
VerbenaをOSSリリースに向けて準備するため、プロジェクトを国際化する必要があります。英語をプライマリ言語とし、日本語をサポートするフォールバックとして設定することで、Railsのベストプラクティスに沿い、非日本語話者でも利用可能になります。

## 注意事項
- `eml_inputs` 機能はEMLアップロードとAPIインタラクションのテスト向けの開発者向けデモです。そのため、包括的なテスト（例: ビューやコントローラーのRSpecスペック）は未整備ですが、デモ用途のため現時点では許容します。本番向け機能については今後テスト追加を検討します。
- 既存機能への破壊的変更はありません。すべての翻訳が適切にフォールバックします。
- 手動検証済み: Railsコンソール等で `I18n.locale` を切り替え、両言語でUIが正しくレンダリングされることを確認しています。

## 今後の改善
- ロケール選択のUI追加
- `i18n-tasks` を使用した翻訳健全性チェック
- 本番向け機能のテスト追加

## テスト
- `bundle install` を実行して依存関係を更新
- `bin/dev` でアプリを起動し、Railsコンソール等で `I18n.locale` を切り替えてEML入力フォームを両ロケールでテスト
- （推奨）I18nキーのRSpecテストやロケールフォールバックの統合テストを追加

 
Closes #28

-----

This pull request introduces internationalization (i18n) support for user-facing text in the EML input feature, adds Japanese contribution guidelines, and improves documentation. The most important changes are grouped below:

**Internationalization (i18n) of EML Input Feature:**

* All user-visible messages, labels, placeholders, and flash messages in the `eml_inputs_controller.rb` and the EML input form (`_form_body.html.erb`) now use `I18n.t` for translation, replacing hardcoded Japanese strings. This includes error messages, form labels, and notifications to users. [[1]](diffhunk://#diff-45aee6f0d8a956d91f5693e07eb51222f98cb4425ec9e655cfe3352239b85261L33-R43) [[2]](diffhunk://#diff-45aee6f0d8a956d91f5693e07eb51222f98cb4425ec9e655cfe3352239b85261L95-R105) [[3]](diffhunk://#diff-45aee6f0d8a956d91f5693e07eb51222f98cb4425ec9e655cfe3352239b85261L116-R126) [[4]](diffhunk://#diff-45aee6f0d8a956d91f5693e07eb51222f98cb4425ec9e655cfe3352239b85261L146-R146) [[5]](diffhunk://#diff-45aee6f0d8a956d91f5693e07eb51222f98cb4425ec9e655cfe3352239b85261L197-R197) [[6]](diffhunk://#diff-19d32c47590f00a44f654e6a1d557435120f2152a4298599e5e9588a6b985cc9L3-R9) [[7]](diffhunk://#diff-19d32c47590f00a44f654e6a1d557435120f2152a4298599e5e9588a6b985cc9L25-R84)

**Documentation Improvements:**

* Added a comprehensive Japanese README file (`README.ja.md`) describing the application's purpose, setup, usage, maintenance, and development instructions.
* Updated the English `README.md` to match the structure and content of the Japanese version, ensuring consistency and clarity for both audiences.
* Added a Japanese-language contribution guide to `CONTRIBUTING.md`, outlining the steps for proposing and submitting changes.

**Dependency Updates:**

* Added the `rails-i18n` gem to the `Gemfile` to support Rails internationalization features.